### PR TITLE
Add package name and version substitution in XML output

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"

--- a/src/Muddy.js
+++ b/src/Muddy.js
@@ -512,6 +512,12 @@ export default class Muddy {
 
     xmlFragments.forEach(e => root.import(e))
     const output = root.end({prettyPrint: true})
+      .replaceAll(/(@PKGNAME@|__PKGNAME__)/g, mfile.package)
+      .replaceAll(/(@VERSION@|__VERSION__)/g, mfile.version)
+
+    glog.info(`Substituted all instances of (@PKGNAME@|__PKGNAME__) with '${mfile.package}'`)
+    glog.info(`Substituted all instances of (@VERSION@|__VERSION__) with '${mfile.version}'`)
+
     const outputFile = workDirectory.getFile(`${mfile.package}.xml`)
 
     glog.info(`XML created successfully, writing it to disk`)

--- a/src/Muddy.js
+++ b/src/Muddy.js
@@ -515,8 +515,8 @@ export default class Muddy {
       .replaceAll(/(@PKGNAME@|__PKGNAME__)/g, mfile.package)
       .replaceAll(/(@VERSION@|__VERSION__)/g, mfile.version)
 
-    glog.info(`Substituted all instances of (@PKGNAME@|__PKGNAME__) with '${mfile.package}'`)
-    glog.info(`Substituted all instances of (@VERSION@|__VERSION__) with '${mfile.version}'`)
+    glog.info(`Substituted all instances of '(@PKGNAME@|__PKGNAME__)' with '${mfile.package}'`)
+    glog.info(`Substituted all instances of '(@VERSION@|__VERSION__)' with '${mfile.version}'`)
 
     const outputFile = workDirectory.getFile(`${mfile.package}.xml`)
 


### PR DESCRIPTION
# Version Bump and XML Template Variable Substitution

This PR bumps the package version from 0.1.0 to 0.2.0 and adds template variable substitution functionality to the XML generation process.

The XML output now automatically replaces all instances of `@PKGNAME@`, `__PKGNAME__`, `@VERSION@`, and `__VERSION__` with the actual package name and version values from the manifest file. This allows for more dynamic XML templates that automatically update with the package information.

The substitution process is logged to provide visibility into the replacements being made during XML generation.