### PR TITLE
Bump version to 0.3.0 and update toolkit dependency with default module parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"
@@ -55,7 +55,7 @@
   "dependencies": {
     "@gesslar/actioneer": "^2.2.0",
     "@gesslar/colours": "^0.8.0",
-    "@gesslar/toolkit": "^3.33.0",
+    "@gesslar/toolkit": "^3.33.1",
     "adm-zip": "^0.5.16",
     "commander": "^14.0.3",
     "xmlbuilder2": "^4.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.8.0
         version: 0.8.0
       '@gesslar/toolkit':
-        specifier: ^3.33.0
-        version: 3.33.0
+        specifier: ^3.33.1
+        version: 3.33.1
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
@@ -89,8 +89,8 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@gesslar/toolkit@3.33.0':
-    resolution: {integrity: sha512-b1X42ncTNFu5+Qm+FTU7vgpobB4sLDV8cLbAx77RNNUyGxoFmgR4a2t6OnUhQeCddv2qHFo/izm9LbrBSxYVAw==}
+  '@gesslar/toolkit@3.33.1':
+    resolution: {integrity: sha512-csao8zoxM2aVuRmYtHGpkwglzpXywpIznV7UQRafp41TakDoETgHc2k58NSIuukM3/Zb8+IOnWthJGkEEaC11g==}
     engines: {node: '>=24.13.0'}
 
   '@gesslar/uglier@1.4.0':
@@ -546,11 +546,11 @@ snapshots:
 
   '@gesslar/actioneer@2.2.0':
     dependencies:
-      '@gesslar/toolkit': 3.33.0
+      '@gesslar/toolkit': 3.33.1
 
   '@gesslar/colours@0.8.0': {}
 
-  '@gesslar/toolkit@3.33.0':
+  '@gesslar/toolkit@3.33.1':
     dependencies:
       '@gesslar/colours': 0.8.0
       ajv: 8.17.1
@@ -561,7 +561,7 @@ snapshots:
   '@gesslar/uglier@1.4.0(eslint@10.0.0)':
     dependencies:
       '@gesslar/colours': 0.8.0
-      '@gesslar/toolkit': 3.33.0
+      '@gesslar/toolkit': 3.33.1
       '@skarab/detect-package-manager': 1.0.0
       '@stylistic/eslint-plugin': 5.7.1(eslint@10.0.0)
       eslint: 10.0.0

--- a/src/modules/MudletModule.js
+++ b/src/modules/MudletModule.js
@@ -18,7 +18,7 @@ export default class MudletModule {
    * @param {string} [object.script] - Lua script content
    */
   constructor(object={}) {
-    const {name, isFolder, isActive, packageName="", script=""} = (object ?? {})
+    const {name, isFolder="no", isActive="yes", packageName="", script=""} = (object ?? {})
 
     Valid.type(name, "String", {allowEmpty: false})
     Valid.assert(isFolder === "yes" || isFolder === "no", "isFolder must be 'yes' or 'no'.")


### PR DESCRIPTION
# Bump version to 0.3.0 and update dependencies

This PR:
- Bumps the package version from 0.2.0 to 0.3.0
- Updates @gesslar/toolkit dependency from 3.33.0 to 3.33.1
- Sets default values for `isFolder` and `isActive` parameters in the MudletModule constructor to "no" and "yes" respectively