### PR TITLE
Add XML output and update version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"


### PR DESCRIPTION
Introduce XML output functionality and update the version number to 0.4.0. The changes also ensure that if no description is provided in the mfile, it will be populated from the README.md file if available.