### PR TITLE
Bump version to 0.4.2 and remove file deletion before write

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"

--- a/src/Muddy.js
+++ b/src/Muddy.js
@@ -687,8 +687,8 @@ export default class Muddy {
       path: Data.prepend(FileSystem.relativeOrAbsolute(projectDirectory, mpackageFile), "/")
     })
 
-    if(await outputFile.exists)
-      await outputFile.delete()
+    // if(await outputFile.exists)
+    //   await outputFile.delete()
 
     await outputFile.write(Data.append(output, "\n"))
 

--- a/src/Muddy.js
+++ b/src/Muddy.js
@@ -687,9 +687,6 @@ export default class Muddy {
       path: Data.prepend(FileSystem.relativeOrAbsolute(projectDirectory, mpackageFile), "/")
     })
 
-    // if(await outputFile.exists)
-    //   await outputFile.delete()
-
     await outputFile.write(Data.append(output, "\n"))
 
     const size = await outputFile.size()


### PR DESCRIPTION
# Bump version to 0.4.2 and remove file deletion before write

This PR increments the package version from 0.4.1 to 0.4.2 and comments out the code that was deleting the output file before writing to it. The file deletion step is no longer necessary as the write operation will overwrite the existing file.