### PR TITLE
Bump version to 1.1.0 and add ignore patterns support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,34 @@ Also, shout out to [@Edru2](https://github.com/Edru2) for
 
 Which is exactly how everybody likes their sex, yes? Yes. Okay.
 
+## Features unique to muddy
+
+### Ignore patterns
+
+muddy supports an `ignore` field in your `mfile` that lets you exclude files
+from both module collection and resource injection. This is not available in
+muddler.
+
+Add an `ignore` array to your `mfile` with glob patterns:
+
+```json
+{
+  "package": "MyPackage",
+  "version": "1.0.0",
+  "ignore": ["**/drafts/**", "**/wip/**", "**/experimental_*"]
+}
+```
+
+Patterns are matched against relative paths within `src/`. They apply to:
+
+- **Module collection** — any `scripts.json`, `aliases.json`, etc. matching an
+  ignore pattern will be skipped entirely, along with their associated Lua files.
+- **Resource injection** — any files under `src/resources/` matching an ignore
+  pattern will not be copied into the `.mpackage`.
+
+Standard glob syntax is supported (e.g. `*`, `**`, `?`). If `ignore` is omitted
+or empty, all files are included as usual.
+
 ## License
 
 `@gesslar/muddy` is released into the public domain under the [0BSD](LICENSE.txt).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"

--- a/src/Muddy.js
+++ b/src/Muddy.js
@@ -135,6 +135,7 @@ export default class Muddy {
          `object containing package name and file location at build end.`
       )
 
+    mfile.ignore = mfile.ignore ?? []
     mfile.description = mfile.description ?? ""
 
     if(!mfile.description) {
@@ -161,9 +162,9 @@ export default class Muddy {
    * @returns {Promise<Array<ModuleTypeContext>>} Array of contexts for each module type
    */
   #splitPackageDirs = async ctx => {
-    const {srcDirectory} = ctx
+    const {srcDirectory, mfile} = ctx
 
-    return Type.PLURAL.map(e => ({kind: e, srcDirectory}))
+    return Type.PLURAL.map(e => ({kind: e, srcDirectory, ignore: mfile.ignore}))
   }
 
   /**
@@ -192,13 +193,15 @@ export default class Muddy {
    * @returns {Promise<JsonFilesContext>} Context with jsonFiles array
    */
   #scanForPackageJsonFiles = async ctx => {
-    const {kind, srcDirectory} = ctx
+    const {kind, srcDirectory, ignore} = ctx
 
     glog.info(c`Scanning for {${kind}}${kind}{/}`)
 
     const pattern = `**/${kind}.json`
     const found = await srcDirectory.glob(pattern)
-    const jsonFiles = found.files
+    const jsonFiles = found.files.filter(
+      f => !this.#isIgnored(f.relativeTo(srcDirectory), ignore)
+    )
 
     jsonFiles.forEach(e =>
       glog
@@ -610,32 +613,34 @@ export default class Muddy {
     // Now we just literally copy everything from resources into the main work
     // directory. Mudlet will do the same thing, allowing the entire structure
     // to be replicated in a predicktable fashion.
-    await this.#recursiveResourcesCopy(resourcesDirectory, workDirectory)
+    await this.#recursiveResourcesCopy(
+      resourcesDirectory, workDirectory, mfile.ignore
+    )
 
     return ctx
   }
 
   /**
-   * Recursively copies files and directories from resources to work directory.
+   * Copies files from resources to work directory, respecting ignore patterns.
    *
    * @private
    * @param {DirectoryObject} res - The source resources directory
    * @param {DirectoryObject} work - The destination work directory
+   * @param {Array<string>} ignore - Glob patterns to ignore
    * @returns {Promise<void>}
    */
-  #recursiveResourcesCopy = async(res, work) => {
-    const {files, directories} = await res.read()
+  #recursiveResourcesCopy = async(res, work, ignore) => {
+    const found = await res.glob("**/*")
+    const files = found.files.filter(
+      f => !this.#isIgnored(f.relativeTo(res), ignore)
+    )
 
-    await work.assureExists({recursive: true})
-
-    // Witchcraft. I will not be taking questions at this time.
     await Promised.settle(
-      [files, directories].flat().map(async e => {
-        if(e.isFile) {
-          await e.copy(work.getFile(e.name).path)
-        } else if(e.isDirectory) {
-          await this.#recursiveResourcesCopy(e, work.getDirectory(e.name))
-        }
+      files.map(async file => {
+        const relative = file.relativeTo(res)
+        const dest = work.getFile(relative)
+        await dest.parent.assureExists({recursive: true})
+        await file.copy(dest.path)
       })
     )
   }
@@ -766,4 +771,18 @@ export default class Muddy {
    * @returns {string} ISO timestamp in format YYYY-MM-DDTHH:mm:ss+0000
    */
   #iso = () => new Date().toISOString().replace(/\.\d{3}Z$/, "+0000")
+
+  /**
+   * Checks whether a relative path matches any of the ignore patterns.
+   *
+   * @private
+   * @param {string} relativePath - The relative file path to check
+   * @param {Array<string>} patterns - Glob patterns to match against
+   * @returns {boolean} True if the path should be ignored
+   */
+  #isIgnored = (relativePath, patterns) =>
+    patterns.length > 0
+    && patterns.some(
+      pat => path.matchesGlob(relativePath, pat)
+    )
 }

--- a/src/modules/Mfile.js
+++ b/src/modules/Mfile.js
@@ -2,7 +2,7 @@ const Mfile = new Object()
 
 Mfile.FIELDS = Object.freeze([
   "package", "title", "description", "version", "author", "icon",
-  "dependencies", "outputFile",
+  "dependencies", "outputFile", "ignore",
 ])
 
 Mfile.MFILE_TO_CONFIG = Object.freeze(new Map([

--- a/test/unit/ignore.test.js
+++ b/test/unit/ignore.test.js
@@ -1,0 +1,190 @@
+import {describe, it, before, after} from "node:test"
+import assert from "node:assert/strict"
+import {DirectoryObject, FileObject, Glog} from "@gesslar/toolkit"
+import {mkdtempSync} from "node:fs"
+import {rm} from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import AdmZip from "adm-zip"
+
+import Muddy from "../../src/Muddy.js"
+
+/**
+ * Creates a minimal muddy project in a temp directory.
+ *
+ * @param {object} [mfileOverrides] - Extra fields merged into mfile
+ * @returns {Promise<DirectoryObject>} The project directory
+ */
+async function createProject(mfileOverrides = {}) {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "muddy-test-"))
+  const projectDir = new DirectoryObject(tmp)
+
+  // Write mfile
+  const mfile = Object.assign({
+    package: "TestPkg",
+    title: "Test Package",
+    description: "test",
+    version: "1.0.0",
+    author: "Test",
+    icon: "",
+    dependencies: "",
+    outputFile: false,
+  }, mfileOverrides)
+
+  await projectDir.getFile("mfile").write(JSON.stringify(mfile))
+
+  // Create src/scripts with two script groups: kept/ and ignored/
+  const scriptsKept = projectDir
+    .getDirectory("src")
+    .getDirectory("scripts")
+    .getDirectory("kept")
+  await scriptsKept.assureExists({recursive: true})
+
+  await scriptsKept.getFile("scripts.json").write(JSON.stringify([
+    {isActive: "yes", isFolder: "no", name: "KeepMe", script: ""},
+  ]))
+  await scriptsKept.getFile("KeepMe.lua").write("-- kept")
+
+  const scriptsIgnored = projectDir
+    .getDirectory("src")
+    .getDirectory("scripts")
+    .getDirectory("drafts")
+  await scriptsIgnored.assureExists({recursive: true})
+
+  await scriptsIgnored.getFile("scripts.json").write(JSON.stringify([
+    {isActive: "yes", isFolder: "no", name: "IgnoreMe", script: ""},
+  ]))
+  await scriptsIgnored.getFile("IgnoreMe.lua").write("-- ignored")
+
+  // Create src/resources with two files: one kept and one ignored
+  const resources = projectDir.getDirectory("src").getDirectory("resources")
+  await resources.assureExists({recursive: true})
+  await resources.getFile("keep.txt").write("kept resource")
+
+  const resSubdir = resources.getDirectory("wip")
+  await resSubdir.assureExists({recursive: true})
+  await resSubdir.getFile("draft.txt").write("ignored resource")
+
+  return projectDir
+}
+
+function silentGlog() {
+  return new Glog()
+    .withName("TEST")
+    .noDisplayName()
+}
+
+describe("ignore", () => {
+  let projectDir
+
+  after(async() => {
+    if(projectDir)
+      await rm(projectDir.path, {recursive: true, force: true})
+  })
+
+  describe("without ignore patterns", () => {
+    let mpackagePath
+
+    before(async() => {
+      projectDir = await createProject()
+      await new Muddy().run(projectDir, silentGlog())
+      mpackagePath = projectDir
+        .getDirectory("build")
+        .getFile("TestPkg.mpackage")
+        .path
+    })
+
+    it("should include all scripts in the package", () => {
+      const zip = new AdmZip(mpackagePath)
+      const xml = zip.readAsText("TestPkg.xml")
+
+      assert.ok(xml.includes("KeepMe"), "expected KeepMe in XML")
+      assert.ok(xml.includes("IgnoreMe"), "expected IgnoreMe in XML")
+    })
+
+    it("should include all resource files in the package", () => {
+      const zip = new AdmZip(mpackagePath)
+      const entries = zip.getEntries().map(e => e.entryName)
+
+      assert.ok(entries.includes("keep.txt"), "expected keep.txt")
+      assert.ok(
+        entries.some(e => e.includes("draft.txt")),
+        "expected draft.txt"
+      )
+    })
+  })
+
+  describe("with ignore patterns", () => {
+    let mpackagePath
+
+    before(async() => {
+      // Clean up previous project
+      if(projectDir)
+        await rm(projectDir.path, {recursive: true, force: true})
+
+      projectDir = await createProject({
+        ignore: ["**/drafts/**", "**/wip/**"],
+      })
+      await new Muddy().run(projectDir, silentGlog())
+      mpackagePath = projectDir
+        .getDirectory("build")
+        .getFile("TestPkg.mpackage")
+        .path
+    })
+
+    it("should include non-ignored scripts", () => {
+      const zip = new AdmZip(mpackagePath)
+      const xml = zip.readAsText("TestPkg.xml")
+
+      assert.ok(xml.includes("KeepMe"), "expected KeepMe in XML")
+    })
+
+    it("should exclude ignored scripts", () => {
+      const zip = new AdmZip(mpackagePath)
+      const xml = zip.readAsText("TestPkg.xml")
+
+      assert.ok(!xml.includes("IgnoreMe"), "IgnoreMe should be excluded")
+    })
+
+    it("should include non-ignored resources", () => {
+      const zip = new AdmZip(mpackagePath)
+      const entries = zip.getEntries().map(e => e.entryName)
+
+      assert.ok(entries.includes("keep.txt"), "expected keep.txt")
+    })
+
+    it("should exclude ignored resources", () => {
+      const zip = new AdmZip(mpackagePath)
+      const entries = zip.getEntries().map(e => e.entryName)
+
+      assert.ok(
+        !entries.some(e => e.includes("draft.txt")),
+        "draft.txt should be excluded"
+      )
+    })
+  })
+
+  describe("with empty ignore array", () => {
+    let mpackagePath
+
+    before(async() => {
+      if(projectDir)
+        await rm(projectDir.path, {recursive: true, force: true})
+
+      projectDir = await createProject({ignore: []})
+      await new Muddy().run(projectDir, silentGlog())
+      mpackagePath = projectDir
+        .getDirectory("build")
+        .getFile("TestPkg.mpackage")
+        .path
+    })
+
+    it("should include everything when ignore is empty", () => {
+      const zip = new AdmZip(mpackagePath)
+      const xml = zip.readAsText("TestPkg.xml")
+
+      assert.ok(xml.includes("KeepMe"), "expected KeepMe")
+      assert.ok(xml.includes("IgnoreMe"), "expected IgnoreMe")
+    })
+  })
+})

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -13,7 +13,7 @@
     "rootDir": "./src",
     // Module system
     "module": "ES2022",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "target": "ES2022",
     // Strict type checking (helps generate better types)
     "strict": false,


### PR DESCRIPTION
This pull request adds support for ignoring files and directories during package building through a new `ignore` field in the mfile configuration.

**Key Changes:**

- Added `ignore` field to mfile schema that accepts an array of glob patterns
- Modified file scanning logic to filter out files matching ignore patterns when processing scripts, aliases, triggers, and other module types
- Updated resource copying to respect ignore patterns, preventing excluded files from being included in the final package
- Implemented `#isIgnored` helper method to check if file paths match any ignore patterns
- Bumped package version from 1.0.0 to 1.1.0

**Testing:**

Added comprehensive test coverage verifying that:
- Files matching ignore patterns are excluded from both XML configuration and package resources
- Non-matching files are still included normally  
- Empty ignore arrays work as expected
- The feature works across different file types (scripts, resources, etc.)

This allows developers to exclude work-in-progress files, drafts, or other temporary content from their built packages by specifying patterns like `["**/drafts/**", "**/wip/**"]` in their mfile.