### PR TITLE
Bump version to 1.3.0 and add project generation feature

### DIFF
--- a/.changeset/long-dots-knock.md
+++ b/.changeset/long-dots-knock.md
@@ -1,0 +1,5 @@
+---
+"@gesslar/muddy": minor
+---
+
+Bump version to 1.3.0 and add project generation feature

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ npm i -d @gesslar/muddy
 
 ## Post Hocktuah
 
-I just realised that I didn't implement creating or scaffolding a new project
-like **muddler** does. Maybe in the next version.
-
 Also, shout out to [@Edru2](https://github.com/Edru2) for
 [DeMuddler](https://github.com/Edru2/DeMuddler) which is just sex on a stick.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@gesslar/muddy",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "0BSD",
       "dependencies": {
-        "@gesslar/actioneer": "^3.0.0",
+        "@gesslar/actioneer": "^3.0.1",
         "@gesslar/colours": "^1.0.0",
-        "@gesslar/toolkit": "^5.0.0",
+        "@gesslar/toolkit": "^5.0.1",
         "adm-zip": "^0.5.17",
         "commander": "^14.0.3",
         "xmlbuilder2": "^4.0.3"
@@ -171,15 +171,15 @@
       }
     },
     "node_modules/@gesslar/actioneer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/actioneer/-/actioneer-3.0.0.tgz",
-      "integrity": "sha512-hg478HUqEIZUBElESCzpupTBNiRNDeG+Coo44jzVS8Xkj8ge9/mVTWLT57bfW0Mt09OsPnWgGQ2y+vG9a7wx7Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@gesslar/actioneer/-/actioneer-3.0.1.tgz",
+      "integrity": "sha512-jATyibidf6qbRe49R6Ih2+8fCyik4/HwD54u+y2QGgpM4QtjMpAbZRuYK7h13M33/t208Tdc7TuW58wxnqmbzw==",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/toolkit": "^5.0.0"
       },
       "engines": {
-        "node": ">=24.13.0"
+        "node": ">=24.11.0"
       }
     },
     "node_modules/@gesslar/colours": {
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/@gesslar/toolkit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.0.0.tgz",
-      "integrity": "sha512-SsyM9aqlpKKwpZMorNH9BqgnpR+3/W7T7WRyRGNn0NYweABeVtdjLtK623T6Fl+cMWvNJUOnuKtitMqnyyZCdQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.0.1.tgz",
+      "integrity": "sha512-Z2rkII7Hvrsp/LHvs2tAZ2iTz6j9Pfm4euPbMt6ylOc6VMe+eCPNLnKFmpSa6kKTjS3Y4NST0+sfZ8s5DNO1FQ==",
       "hasInstallScript": true,
       "license": "0BSD",
       "dependencies": {
@@ -208,7 +208,7 @@
         "yaml": "^2.8.3"
       },
       "engines": {
-        "node": ">=24.13.0"
+        "node": ">=24.11.0"
       }
     },
     "node_modules/@gesslar/uglier": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "1.2.0",
+  "version": "1.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"
@@ -52,9 +52,9 @@
   },
   "packageManager": "npm@11.12.1",
   "dependencies": {
-    "@gesslar/actioneer": "^3.0.0",
+    "@gesslar/actioneer": "^3.0.1",
     "@gesslar/colours": "^1.0.0",
-    "@gesslar/toolkit": "^5.0.0",
+    "@gesslar/toolkit": "^5.0.1",
     "adm-zip": "^0.5.17",
     "commander": "^14.0.3",
     "xmlbuilder2": "^4.0.3"

--- a/src/Generate.js
+++ b/src/Generate.js
@@ -1,0 +1,569 @@
+import c from "@gesslar/colours"
+import {DirectoryObject} from "@gesslar/toolkit"
+import {execSync} from "node:child_process"
+import path from "node:path"
+import readline from "node:readline"
+
+/**
+ * @typedef {object} GenerateOptions
+ * @property {string} name - Project name
+ * @property {string} version - Starting version
+ * @property {string} author - Author name
+ * @property {string} title - One-line description
+ * @property {boolean} scripts - Include example scripts
+ * @property {boolean} aliases - Include example aliases
+ * @property {boolean} triggers - Include example triggers
+ * @property {boolean} keys - Include example keybindings
+ * @property {boolean} timers - Include example timers
+ * @property {boolean} gitignore - Include .gitignore
+ */
+
+class Generate {
+  /** @type {readline.Interface} */
+  #rl
+
+  /** @type {string[]} */
+  #lineBuffer = []
+
+  /** @type {Function|null} */
+  #lineResolve = null
+
+  /**
+   * Run the interactive project generator.
+   *
+   * @param {DirectoryObject} cwd - The directory to generate the project in.
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger instance.
+   * @returns {Promise<void>}
+   */
+  async run(cwd, glog) {
+    this.#rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    })
+
+    this.#rl.on("line", line => {
+      if(this.#lineResolve) {
+        const resolve = this.#lineResolve
+        this.#lineResolve = null
+        resolve(line)
+      } else {
+        this.#lineBuffer.push(line)
+      }
+    })
+
+    try {
+      glog.info("Creating new muddy project!")
+
+      console.log()
+      console.log(
+        `Please provide the following information to generate your`
+        + ` project skeleton.`
+      )
+
+      console.log(
+        `The defaults will be provided in [], if you enter nothing the`
+        + ` default will be used.`
+      )
+
+      console.log()
+
+      const gitUser = this.#getGitUser()
+
+      const name = await this.#ask(
+        `Project name: `
+      )
+
+      if(!name) {
+        glog.error("Project name is required.")
+
+        return
+      }
+
+      const targetDir = new DirectoryObject(
+        path.join(cwd.path, name)
+      )
+
+      if(await targetDir.exists) {
+        glog.error(
+          `Directory '${name}' already exists.`
+        )
+
+        return
+      }
+
+      console.log()
+      console.log(`Setting up a project for '${name}'...`)
+      console.log()
+
+      const version = await this.#ask(
+        `What version will this project start at? [1.0.0]: `
+      ) || "1.0.0"
+
+      const author = await this.#ask(
+        `What is the author name of this project? [${gitUser}]: `
+      ) || gitUser
+
+      const title = await this.#ask(
+        `Briefly describe this project: ["${name}" by ${author}]: `
+      ) || `"${name}" by ${author}`
+
+      console.log()
+      console.log(`For the following questions, answer:`)
+      console.log()
+      console.log(`  'y' if you want the category setup with an example item`)
+      console.log(`  'n' if you do not`)
+      console.log()
+      console.log(`You can always add them later if you need them.`)
+      console.log()
+
+      const scripts = await this.#askYN("Would you like example scripts? [y]: ", true)
+      const aliases = await this.#askYN("Would you like example aliases? [n]: ", false)
+      const triggers = await this.#askYN("Would you like example triggers? [n]: ", false)
+      const keys = await this.#askYN("Would you like example keybindings? [n]: ", false)
+      const timers = await this.#askYN("Would you like example timers? [n]: ", false)
+
+      console.log()
+
+      const gitignore = await this.#askYN(
+        `Would you like a .gitignore file for muddy generated files? [y]: `,
+        true
+      )
+
+      console.log()
+      console.log("Project definition:")
+
+      glog.table({
+        Name: name,
+        Version: version,
+        Author: author,
+        Title: title,
+        Scripts: scripts ? "yes" : "no",
+        Aliases: aliases ? "yes" : "no",
+        Triggers: triggers ? "yes" : "no",
+        Keys: keys ? "yes" : "no",
+        Timers: timers ? "yes" : "no",
+      })
+
+      console.log()
+
+      const confirm = await this.#askYN(
+        `Continue to generate this package? y/n [y]: `,
+        true
+      )
+
+      if(!confirm) {
+        glog.info("Generation cancelled.")
+
+        return
+      }
+
+      const opts = {
+        name, version, author, title,
+        scripts, aliases, triggers,
+        keys, timers, gitignore,
+      }
+
+      console.log()
+      await this.#generate(cwd, glog, opts)
+      console.log()
+
+      glog.success(
+        c`Your project and any generated files can be found`
+        + c` in: {info}${cwd.getDirectory(name).path}{/}`
+      )
+    } finally {
+      this.#rl.close()
+    }
+  }
+
+  /**
+   * Generate the project skeleton.
+   *
+   * @param {DirectoryObject} cwd - Parent directory.
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger.
+   * @param {GenerateOptions} opts - Generation options.
+   * @returns {Promise<void>}
+   */
+  async #generate(cwd, glog, opts) {
+    const projectDir = cwd.getDirectory(opts.name)
+    const srcDir = projectDir.getDirectory("src")
+    await srcDir.assureExists({recursive: true})
+
+    // Write mfile
+    const mfile = {
+      package: opts.name,
+      version: opts.version,
+      author: opts.author,
+      title: opts.title,
+      outputFile: true,
+    }
+    await projectDir.getFile("mfile")
+      .write(JSON.stringify(mfile, null, 2) + "\n")
+
+    // Write .gitignore
+    if(opts.gitignore) {
+      await projectDir.getFile(".gitignore")
+        .write("build/\n.output\n")
+    }
+
+    // Write README.md
+    await projectDir.getFile("README.md")
+      .write(this.#readmeTemplate(opts))
+
+    // Generate module types
+    if(opts.scripts) {
+      await this.#generateScripts(srcDir, glog, opts)
+    }
+
+    if(opts.aliases) {
+      await this.#generateAliases(srcDir, glog, opts)
+    }
+
+    if(opts.triggers) {
+      await this.#generateTriggers(
+        srcDir, glog, opts
+      )
+    }
+
+    if(opts.timers) {
+      await this.#generateTimers(srcDir, glog, opts)
+    }
+
+    if(opts.keys) {
+      await this.#generateKeys(srcDir, glog, opts)
+    }
+  }
+
+  /**
+   * Generate example scripts.
+   *
+   * @param {DirectoryObject} srcDir - The src directory.
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger.
+   * @param {GenerateOptions} opts - Generation options.
+   * @returns {Promise<void>}
+   */
+  async #generateScripts(srcDir, glog, opts) {
+    const dir = new DirectoryObject(
+      path.join(srcDir.path, "scripts", opts.name)
+    )
+    await dir.assureExists({recursive: true})
+
+    const safeName = this.#luaSafe(opts.name)
+    const scriptName = `${safeName}_example_script`
+
+    await dir.getFile("scripts.json").write(
+      JSON.stringify([
+        {
+          name: scriptName,
+          eventHandlerList: ["sysInstall"],
+        },
+      ], null, 2) + "\n"
+    )
+
+    await dir.getFile(`${scriptName}.lua`).write(
+      `-- define ${scriptName}()`
+      + ` for use as an event handler\n`
+      + `function ${scriptName}(event, ...)\n`
+      + `  echo("Received event "`
+      + ` .. event .. " with arguments:\\n")\n`
+      + `  display(...)\n`
+      + `end\n`
+    )
+
+    glog.success(`{scripts}scripts{/} generation completed successfully`)
+  }
+
+  /**
+   * Generate example aliases.
+   *
+   * @param {DirectoryObject} srcDir - The src directory.
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger.
+   * @param {GenerateOptions} opts - Generation options.
+   * @returns {Promise<void>}
+   */
+  async #generateAliases(srcDir, glog, opts) {
+    const dir = new DirectoryObject(
+      path.join(srcDir.path, "aliases", opts.name)
+    )
+    await dir.assureExists({recursive: true})
+
+    await dir.getFile("aliases.json").write(
+      JSON.stringify([
+        {
+          name: opts.name,
+          regex: `^${opts.name}$`,
+        },
+      ], null, 2) + "\n"
+    )
+
+    const safeName = this.#luaSafe(opts.name)
+    await dir.getFile(`${safeName}.lua`).write(
+      `echo([[\n`
+      + `  A circus performer named Brian\n`
+      + `  Once smiled as he rode on a lion\n`
+      + `  They came back from the ride,\n`
+      + `  But with Brian inside,\n`
+      + `  And the smile on the face`
+      + ` of the lion!\n`
+      + `]])\n`
+    )
+
+    glog.success(c`{aliases}aliases{/} generation completed successfully`)
+  }
+
+  /**
+   * Generate example triggers.
+   *
+   * @param {DirectoryObject} srcDir - The src directory.
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger.
+   * @param {GenerateOptions} opts - Generation options.
+   * @returns {Promise<void>}
+   */
+  async #generateTriggers(srcDir, glog, opts) {
+    const dir = new DirectoryObject(
+      path.join(srcDir.path, "triggers", opts.name)
+    )
+    await dir.assureExists({recursive: true})
+
+    await dir.getFile("triggers.json").write(
+      JSON.stringify([
+        {
+          name: "Rats",
+          isFolder: "yes",
+          children: [
+            {
+              name: "Rat in",
+              patterns: [
+                {pattern: "^With a squeak, an? .*rat darts into the room, looking about wildly.$", type: "regex"},
+                {pattern: "^Your eyes are drawn to an? .*rat that darts suddenly into view.$", type: "regex"},
+                {pattern: "^An? .*rat wanders into view, nosing about for food.$", type: "regex"},
+                {pattern: "^An? .*rat noses its way cautiously out of the shadows.$", type: "regex"},
+              ],
+              script: "echo('rat entered!')",
+            },
+            {
+              name: "Rat out",
+              patterns: [
+                {pattern: "^An? .*rat darts into the shadows and disappears.$", type: "regex"},
+                {pattern: "^An? .*rat wanders back into its warren where you may not follow.$", type: "regex"},
+                {pattern: "^With a flick of its small whiskers, an? .*rat dashes out of view.$", type: "regex"},
+              ],
+            },
+          ],
+        },
+        {
+          name: "Equilibrium",
+          highlight: "yes",
+          highlightFG: "#00aa7f",
+          highlightBG: "#aa00ff",
+          patterns: [
+            {pattern: "Regained Equilibrium", type: "substring"},
+          ],
+        },
+        {
+          name: "Everything green",
+          patterns: [
+            {pattern: "2,0", type: "color"},
+          ],
+        },
+      ], null, 2) + "\n"
+    )
+
+    glog.success(c`{triggers}triggers{/} generation completed successfully`)
+
+    await dir.getFile("Rat_out.lua")
+      .write("echo('Rat out!')\n")
+
+    await dir.getFile("Equilibrium.lua").write(
+      "cecho('<cyan>Equilibirum has been regained!"
+      + "\\n')\n"
+    )
+
+    await dir.getFile("Everything_green.lua").write(
+      "debugc(\"A green line came in!"
+      + " We are tracking that as part"
+      + " of project @PKGNAME@\")\n"
+    )
+  }
+
+  /**
+   * Generate example timers.
+   *
+   * @param {DirectoryObject} srcDir - The src directory.
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger.
+   * @param {GenerateOptions} opts - Generation options.
+   * @returns {Promise<void>}
+   */
+  async #generateTimers(srcDir, glog, opts) {
+    const dir = new DirectoryObject(
+      path.join(srcDir.path, "timers", opts.name)
+    )
+    await dir.assureExists({recursive: true})
+
+    await dir.getFile("timers.json").write(
+      JSON.stringify([
+        {
+          name: `${opts.name} anti idle`,
+          minutes: "15",
+        },
+      ], null, 2) + "\n"
+    )
+
+    const safeName = this.#luaSafe(opts.name)
+    const timerLua = `${safeName}_anti_idle`
+    await dir.getFile(`${timerLua}.lua`).write(
+      `if not hasFocus() then\n`
+      + `  send("ql")\n`
+      + `end\n`
+    )
+
+    glog.success(c`{timers}timers{/} generation completed successfully`)
+  }
+
+  /**
+   * Generate example keybindings.
+   *
+   * @param {DirectoryObject} srcDir - The src directory.
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger.
+   * @param {GenerateOptions} opts - Generation options.
+   * @returns {Promise<void>}
+   */
+  async #generateKeys(srcDir, glog, opts) {
+    const dir = new DirectoryObject(
+      path.join(srcDir.path, "keys", opts.name)
+    )
+    await dir.assureExists({recursive: true})
+
+    await dir.getFile("keys.json").write(
+      JSON.stringify([
+        {
+          name: "Clearscreen",
+          keys: "ctrl+shift+alt+c",
+        },
+      ], null, 2) + "\n"
+    )
+
+    await dir.getFile("Clearscreen.lua")
+      .write("clearWindow()\n")
+
+    glog.success(c`{keys}keys{/} generation completed successfully`)
+  }
+
+  /**
+   * Get the git user name, or a fallback.
+   *
+   * @returns {string}
+   */
+  #getGitUser() {
+    try {
+      return execSync(
+        "git config user.name",
+        {encoding: "utf8"}
+      ).trim()
+    } catch {
+      return "MudletUser"
+    }
+  }
+
+  /**
+   * Prompt the user for input.
+   *
+   * @param {string} prompt - The prompt text.
+   * @returns {Promise<string>}
+   */
+  async #ask(prompt) {
+    process.stdout.write(prompt)
+
+    let answer
+    if(this.#lineBuffer.length > 0) {
+      answer = this.#lineBuffer.shift()
+    } else {
+      answer = await new Promise(resolve => {
+        this.#lineResolve = resolve
+      })
+    }
+
+    return answer.trim()
+  }
+
+  /**
+   * Prompt the user for a yes/no answer.
+   *
+   * @param {string} prompt - The prompt text.
+   * @param {boolean} defaultValue - Default if empty input.
+   * @returns {Promise<boolean>}
+   */
+  async #askYN(prompt, defaultValue) {
+    const answer = await this.#ask(prompt)
+    if(!answer) {
+      return defaultValue
+    }
+
+    return answer.toLowerCase().startsWith("y")
+  }
+
+  /**
+   * Sanitize a name for use as a Lua identifier
+   * and filename. Replaces non-word characters with
+   * underscores and strips leading digits.
+   *
+   * @param {string} name - Raw name to sanitize.
+   * @returns {string}
+   */
+  #luaSafe(name) {
+    return name
+      .replaceAll(/[^\w]/g, "_")
+      .replace(/^\d+/, "")
+  }
+
+  /**
+   * Generate README.md content.
+   *
+   * @param {GenerateOptions} opts - Generation options.
+   * @returns {string}
+   */
+  #readmeTemplate(opts) {
+    return `# ${opts.name}
+
+## ${opts.title}
+
+This is a template project created by muddy. It's meant to give you the basic skeleton to get started.
+It is not a complete project, nor does it provide an example of every type of trigger scenario or keybinding corner case. It would make it even more difficult to clear out to make way for your own items.
+It **will** properly muddle and create an mpackage, however.
+For more detailed information on describing your triggers, scripts, etc in the json files, please see the [muddler wiki](https://github.com/demonnic/muddler/wiki)
+
+This space is where I would normally put the description of my package and what it does/why I made it. But if you have a README format you already like, feel free to ignore all this.
+
+## Installation
+
+It's a good idea to provide installation instructions. I like to include a command they can copy/paste into the Mudlet commandline. Like
+
+\`lua uninstallPackage("packageName") installPackage("https://somedomain.org/path/to/my/package/packageName.mpackage")\`
+
+## Usage
+
+Brief introduction to the overall usage. Then break it down to specifics
+
+### Aliases
+
+* \`alias1 <param1>\`
+  * description of what the alias does, and what param1 is if it exists
+    * example usage1
+    * optional example usage2, etc
+* \`alias 2\`
+  * and so on, and so forth
+
+### API
+
+* \`functionName(param1, param2)\`
+  * Then, do the same thing for any Lua API which you want them to be able to use.
+  * This part can be skipped if you have separate API documentation, but keep in mind the README.md file is accessible from the package manager in Mudlet, so this allows you to provide documentation within Mudlet, to a degree.
+
+## Final thoughts, how to contribute, thanks, things like that
+
+I like to put anything which doesn't fit with the above stuff here, at the end. It keeps the documentation like stuff at the top.
+`
+  }
+}
+
+export default Generate

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,6 +5,7 @@ import {Collection, DirectoryObject, FileObject, Glog, Sass, Term} from "@gessla
 import {Command} from "commander"
 import process from "node:process"
 
+import Generate from "./Generate.js"
 import Muddy from "./Muddy.js"
 import Watch from "./Watch.js"
 
@@ -40,6 +41,7 @@ void (async() => {
 
     const program = new Command("muddy")
       .argument("[directory]", "The project directory containing an 'mfile' file and 'src/' directory.")
+      .option("-g, --generate", "Generate a new muddy project skeleton.", false)
       .option("-w, --watch", "Enable watch mode.", false)
       .option("-n, --nerd", "Nerd mode. Advanced error reporting.", false)
       .option("-m, --mfile <path>", "Path to an alternate mfile.")
@@ -54,6 +56,12 @@ void (async() => {
     if(!await cwd.exists) {
       glog.error(`No such directory '${dirArg}'.`)
       process.exit(1)
+    }
+
+    if(opts.generate) {
+      await new Generate().run(cwd, glog)
+
+      return
     }
 
     let mfileObject = null

--- a/test/unit/generate.test.js
+++ b/test/unit/generate.test.js
@@ -1,0 +1,591 @@
+import {after, before, describe, it} from "node:test"
+import assert from "node:assert/strict"
+import {execFile, spawn} from "node:child_process"
+import {readdir, readFile, rm, stat} from "node:fs/promises"
+import {mkdtempSync} from "node:fs"
+import {promisify} from "node:util"
+import path from "node:path"
+import os from "node:os"
+import {fileURLToPath} from "node:url"
+
+const exec = promisify(execFile)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI = path.resolve(__dirname, "../../src/cli.js")
+
+/**
+ * Runs the CLI with -g flag, piping input lines to stdin.
+ *
+ * @param {string} tmpDir - Working directory for generation.
+ * @param {string[]} inputLines - Lines to pipe as stdin.
+ * @returns {Promise<{stdout: string, stderr: string, code: number}>}
+ */
+function generate(tmpDir, inputLines) {
+  return new Promise(resolve => {
+    const child = spawn(
+      "node", [CLI, tmpDir, "-g"],
+      {stdio: ["pipe", "pipe", "pipe"]}
+    )
+
+    let stdout = ""
+    let stderr = ""
+    child.stdout.on("data", d => { stdout += d })
+    child.stderr.on("data", d => { stderr += d })
+
+    child.stdin.write(
+      inputLines.join("\n") + "\n"
+    )
+    child.stdin.end()
+
+    child.on("close", code => {
+      resolve({stdout, stderr, code})
+    })
+  })
+}
+
+/**
+ * Checks whether a path exists.
+ *
+ * @param {string} filePath - Absolute path to check.
+ * @returns {Promise<boolean>}
+ */
+async function exists(filePath) {
+  try {
+    await stat(filePath)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Reads a JSON file and returns the parsed content.
+ *
+ * @param {string} filePath - Absolute path to JSON file.
+ * @returns {Promise<*>}
+ */
+async function readJSON(filePath) {
+  const raw = await readFile(filePath, "utf8")
+
+  return JSON.parse(raw)
+}
+
+// All answers accepted, all module types enabled
+const ALL_YES = [
+  "testpkg",     // name
+  "2.0.0",       // version
+  "TestAuthor",  // author
+  "A test pkg",  // title
+  "y",           // scripts
+  "y",           // aliases
+  "y",           // triggers
+  "y",           // keys
+  "y",           // timers
+  "y",           // gitignore
+  "y",           // confirm
+]
+
+// All defaults, only scripts (default yes)
+const ALL_DEFAULTS = [
+  "defpkg",  // name
+  "",        // version -> 1.0.0
+  "",        // author -> git user
+  "",        // title -> default
+  "",        // scripts -> y
+  "",        // aliases -> n
+  "",        // triggers -> n
+  "",        // keys -> n
+  "",        // timers -> n
+  "",        // gitignore -> y
+  "",        // confirm -> y
+]
+
+describe("--generate / -g option", () => {
+  let tmpDir
+
+  before(() => {
+    tmpDir = mkdtempSync(
+      path.join(os.tmpdir(), "muddy-gen-")
+    )
+  })
+
+  after(async () => {
+    if(tmpDir) {
+      await rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it("should appear in --help output", async () => {
+    const {stdout} = await exec("node", [CLI, "--help"])
+    assert.match(stdout, /-g, --generate/)
+  })
+
+  describe("full generation with all types", () => {
+    let result
+    let projectDir
+
+    before(async () => {
+      result = await generate(tmpDir, ALL_YES)
+      projectDir = path.join(tmpDir, "testpkg")
+    })
+
+    it("should exit cleanly", () => {
+      assert.equal(result.code, 0)
+    })
+
+    it("should create the project directory", async () => {
+      assert.ok(
+        await exists(projectDir),
+        "project directory should exist"
+      )
+    })
+
+    it("should create the mfile with correct content", async () => {
+      const mfile = await readJSON(
+        path.join(projectDir, "mfile")
+      )
+      assert.equal(mfile.package, "testpkg")
+      assert.equal(mfile.version, "2.0.0")
+      assert.equal(mfile.author, "TestAuthor")
+      assert.equal(mfile.title, "A test pkg")
+      assert.equal(mfile.outputFile, true)
+    })
+
+    it("should create .gitignore", async () => {
+      const content = await readFile(
+        path.join(projectDir, ".gitignore"), "utf8"
+      )
+      assert.match(content, /build\//)
+      assert.match(content, /\.output/)
+    })
+
+    it("should create README.md", async () => {
+      const content = await readFile(
+        path.join(projectDir, "README.md"), "utf8"
+      )
+      assert.match(content, /# testpkg/)
+      assert.match(content, /A test pkg/)
+    })
+
+    it("should generate scripts", async () => {
+      const dir = path.join(
+        projectDir, "src", "scripts", "testpkg"
+      )
+      assert.ok(
+        await exists(
+          path.join(dir, "scripts.json")
+        ),
+        "scripts.json should exist"
+      )
+      assert.ok(
+        await exists(
+          path.join(dir, "testpkg_example_script.lua")
+        ),
+        "script lua file should exist"
+      )
+
+      const defs = await readJSON(
+        path.join(dir, "scripts.json")
+      )
+      assert.equal(defs[0].name, "testpkg_example_script")
+      assert.deepEqual(
+        defs[0].eventHandlerList, ["sysInstall"]
+      )
+    })
+
+    it("should generate aliases", async () => {
+      const dir = path.join(
+        projectDir, "src", "aliases", "testpkg"
+      )
+      assert.ok(
+        await exists(path.join(dir, "aliases.json")),
+        "aliases.json should exist"
+      )
+      assert.ok(
+        await exists(path.join(dir, "testpkg.lua")),
+        "alias lua file should exist"
+      )
+
+      const defs = await readJSON(
+        path.join(dir, "aliases.json")
+      )
+      assert.equal(defs[0].name, "testpkg")
+      assert.equal(defs[0].regex, "^testpkg$")
+    })
+
+    it("should generate triggers with lua files", async () => {
+      const dir = path.join(
+        projectDir, "src", "triggers", "testpkg"
+      )
+      assert.ok(
+        await exists(path.join(dir, "triggers.json")),
+        "triggers.json should exist"
+      )
+      assert.ok(
+        await exists(path.join(dir, "Rat_out.lua")),
+        "Rat_out.lua should exist"
+      )
+      assert.ok(
+        await exists(path.join(dir, "Equilibrium.lua")),
+        "Equilibrium.lua should exist"
+      )
+      assert.ok(
+        await exists(
+          path.join(dir, "Everything_green.lua")
+        ),
+        "Everything_green.lua should exist"
+      )
+
+      const defs = await readJSON(
+        path.join(dir, "triggers.json")
+      )
+      assert.equal(defs[0].name, "Rats")
+      assert.equal(defs[0].isFolder, "yes")
+      assert.ok(
+        defs[0].children.length > 0,
+        "Rats folder should have children"
+      )
+    })
+
+    it("should generate timers", async () => {
+      const dir = path.join(
+        projectDir, "src", "timers", "testpkg"
+      )
+      assert.ok(
+        await exists(path.join(dir, "timers.json")),
+        "timers.json should exist"
+      )
+      assert.ok(
+        await exists(
+          path.join(dir, "testpkg_anti_idle.lua")
+        ),
+        "timer lua file should exist"
+      )
+
+      const defs = await readJSON(
+        path.join(dir, "timers.json")
+      )
+      assert.equal(defs[0].name, "testpkg anti idle")
+    })
+
+    it("should generate keys", async () => {
+      const dir = path.join(
+        projectDir, "src", "keys", "testpkg"
+      )
+      assert.ok(
+        await exists(path.join(dir, "keys.json")),
+        "keys.json should exist"
+      )
+      assert.ok(
+        await exists(
+          path.join(dir, "Clearscreen.lua")
+        ),
+        "key lua file should exist"
+      )
+
+      const defs = await readJSON(
+        path.join(dir, "keys.json")
+      )
+      assert.equal(defs[0].name, "Clearscreen")
+      assert.equal(defs[0].keys, "ctrl+shift+alt+c")
+    })
+  })
+
+  describe("defaults only (scripts only)", () => {
+    let result
+    let projectDir
+
+    before(async () => {
+      result = await generate(tmpDir, ALL_DEFAULTS)
+      projectDir = path.join(tmpDir, "defpkg")
+    })
+
+    it("should exit cleanly", () => {
+      assert.equal(result.code, 0)
+    })
+
+    it("should use default version 1.0.0", async () => {
+      const mfile = await readJSON(
+        path.join(projectDir, "mfile")
+      )
+      assert.equal(mfile.version, "1.0.0")
+    })
+
+    it("should create scripts (default yes)", async () => {
+      assert.ok(
+        await exists(path.join(
+          projectDir, "src", "scripts",
+          "defpkg", "scripts.json"
+        )),
+        "scripts should be generated by default"
+      )
+    })
+
+    it("should not create aliases (default no)", async () => {
+      assert.ok(
+        !await exists(path.join(
+          projectDir, "src", "aliases"
+        )),
+        "aliases should not exist"
+      )
+    })
+
+    it("should not create triggers (default no)", async () => {
+      assert.ok(
+        !await exists(path.join(
+          projectDir, "src", "triggers"
+        )),
+        "triggers should not exist"
+      )
+    })
+
+    it("should not create keys (default no)", async () => {
+      assert.ok(
+        !await exists(path.join(
+          projectDir, "src", "keys"
+        )),
+        "keys should not exist"
+      )
+    })
+
+    it("should not create timers (default no)", async () => {
+      assert.ok(
+        !await exists(path.join(
+          projectDir, "src", "timers"
+        )),
+        "timers should not exist"
+      )
+    })
+
+    it("should still create .gitignore (default yes)", async () => {
+      assert.ok(
+        await exists(
+          path.join(projectDir, ".gitignore")
+        ),
+        ".gitignore should exist by default"
+      )
+    })
+  })
+
+  describe("selective generation", () => {
+    let projectDir
+
+    before(async () => {
+      const input = [
+        "selectpkg", // name
+        "",          // version
+        "",          // author
+        "",          // title
+        "n",         // scripts: no
+        "y",         // aliases: yes
+        "n",         // triggers: no
+        "y",         // keys: yes
+        "n",         // timers: no
+        "n",         // gitignore: no
+        "y",         // confirm
+      ]
+      await generate(tmpDir, input)
+      projectDir = path.join(tmpDir, "selectpkg")
+    })
+
+    it("should not create scripts when declined", async () => {
+      assert.ok(
+        !await exists(path.join(
+          projectDir, "src", "scripts"
+        )),
+        "scripts should not exist"
+      )
+    })
+
+    it("should create aliases when selected", async () => {
+      assert.ok(
+        await exists(path.join(
+          projectDir, "src", "aliases",
+          "selectpkg", "aliases.json"
+        )),
+        "aliases should exist"
+      )
+    })
+
+    it("should create keys when selected", async () => {
+      assert.ok(
+        await exists(path.join(
+          projectDir, "src", "keys",
+          "selectpkg", "keys.json"
+        )),
+        "keys should exist"
+      )
+    })
+
+    it("should not create .gitignore when declined", async () => {
+      assert.ok(
+        !await exists(
+          path.join(projectDir, ".gitignore")
+        ),
+        ".gitignore should not exist"
+      )
+    })
+  })
+
+  describe("cancellation", () => {
+    it("should not generate when user declines confirmation", async () => {
+      const input = [
+        "cancelled", // name
+        "",          // version
+        "",          // author
+        "",          // title
+        "",          // scripts
+        "",          // aliases
+        "",          // triggers
+        "",          // keys
+        "",          // timers
+        "",          // gitignore
+        "n",         // confirm: no
+      ]
+      const {code} = await generate(tmpDir, input)
+      assert.equal(code, 0, "should exit cleanly")
+      assert.ok(
+        !await exists(
+          path.join(tmpDir, "cancelled")
+        ),
+        "project directory should not be created"
+      )
+    })
+  })
+
+  describe("empty project name", () => {
+    it("should not create anything when name is empty", async () => {
+      const before = await readdir(tmpDir)
+      const input = [""]
+      const {stdout, stderr} = await generate(
+        tmpDir, input
+      )
+      const after = await readdir(tmpDir)
+      const output = stdout + stderr
+      assert.match(
+        output, /required/i,
+        "should mention that name is required"
+      )
+      assert.deepEqual(
+        after, before,
+        "should not create any new directories"
+      )
+    })
+  })
+
+  describe("existing directory guard", () => {
+    it("should refuse to overwrite an existing directory", async () => {
+      // "testpkg" was created by the full generation suite
+      const input = [
+        "testpkg", // already exists
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+      ]
+      const {stdout, stderr} = await generate(
+        tmpDir, input
+      )
+      const output = stdout + stderr
+      assert.match(
+        output, /already exists/i,
+        "should warn that directory exists"
+      )
+    })
+  })
+
+  describe("name sanitization", () => {
+    let projectDir
+
+    before(async () => {
+      const input = [
+        "my-cool-pkg", // name with hyphens
+        "",
+        "",
+        "",
+        "y",  // scripts
+        "y",  // aliases
+        "n",
+        "n",
+        "y",  // timers
+        "",
+        "y",
+      ]
+      await generate(tmpDir, input)
+      projectDir = path.join(tmpDir, "my-cool-pkg")
+    })
+
+    it("should sanitize script lua filename", async () => {
+      const dir = path.join(
+        projectDir, "src", "scripts", "my-cool-pkg"
+      )
+      assert.ok(
+        await exists(
+          path.join(
+            dir, "my_cool_pkg_example_script.lua"
+          )
+        ),
+        "script lua file should use sanitized name"
+      )
+    })
+
+    it("should sanitize script function name in lua", async () => {
+      const content = await readFile(
+        path.join(
+          projectDir, "src", "scripts",
+          "my-cool-pkg",
+          "my_cool_pkg_example_script.lua"
+        ),
+        "utf8"
+      )
+      assert.match(
+        content,
+        /function my_cool_pkg_example_script/,
+        "function name should be a valid Lua identifier"
+      )
+    })
+
+    it("should sanitize script name in JSON", async () => {
+      const defs = await readJSON(
+        path.join(
+          projectDir, "src", "scripts",
+          "my-cool-pkg", "scripts.json"
+        )
+      )
+      assert.equal(
+        defs[0].name,
+        "my_cool_pkg_example_script"
+      )
+    })
+
+    it("should sanitize alias lua filename", async () => {
+      const dir = path.join(
+        projectDir, "src", "aliases", "my-cool-pkg"
+      )
+      assert.ok(
+        await exists(
+          path.join(dir, "my_cool_pkg.lua")
+        ),
+        "alias lua file should use sanitized name"
+      )
+    })
+
+    it("should sanitize timer lua filename", async () => {
+      const dir = path.join(
+        projectDir, "src", "timers", "my-cool-pkg"
+      )
+      assert.ok(
+        await exists(
+          path.join(dir, "my_cool_pkg_anti_idle.lua")
+        ),
+        "timer lua file should use sanitized name"
+      )
+    })
+  })
+})


### PR DESCRIPTION
This pull request adds project scaffolding functionality to muddy, allowing users to generate new project skeletons interactively.

## Changes

- Added new `Generate` class that provides an interactive CLI wizard for creating muddy projects
- Implemented `-g, --generate` flag to trigger the project generation workflow
- The generator prompts users for project details (name, version, author, description) and asks which module types to include (scripts, aliases, triggers, keys, timers)
- Creates complete project structure with:
  - `mfile` configuration with project metadata
  - `src/` directory with organized subdirectories for each selected module type
  - Example files for each module type with working Lua code and JSON definitions
  - Optional `.gitignore` file for muddy build artifacts
  - `README.md` template with documentation structure
- Updated dependencies to newer patch versions of `@gesslar/actioneer` and `@gesslar/toolkit`
- Removed TODO note from README about missing scaffolding functionality
- Bumped package version to 1.3.0
- Added comprehensive test suite covering all generation scenarios including full generation, defaults, selective generation, cancellation, and error cases

The generator uses git configuration to suggest default author names and provides sensible defaults for all options while allowing full customization of the generated project structure.