### PR TITLE
Bump version to 1.4.0 and add build timestamp recording

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"

--- a/src/Muddy.js
+++ b/src/Muddy.js
@@ -105,6 +105,7 @@ export default class Muddy {
         .do("Generate config.lua", this.#generateConfigLua)
         .do("Process resources", this.#processResources)
         .do("Zzzzzzzzzzip", this.#closeTheBarnDoor)
+        .do("Record built stamp", this.#recordBuildStamp)
         .do("Write .output", IF, ctx => ctx.mfile.outputFile, this.#writeOutputFile)
         .done(this.#cleanUp)
     } catch(error) {
@@ -566,11 +567,13 @@ export default class Muddy {
       out.push(`${v} = [[${mfile[k]}]]`)
 
     // This isn't sourced anywhere, so we just make it up.
-    out.push(`created = [[${this.#iso()}]]`)
+    const now = this.#iso()
+    out.push(`created = [[${now}]]`)
     const configFile = workDirectory.getFile("config.lua")
     await configFile.write(out.join("\n"))
 
     ctx.configFile = configFile
+    ctx.built = now
 
     return ctx
   }
@@ -685,6 +688,20 @@ export default class Muddy {
     glog.info(c`{<B}${destXmlFile.path}{B>} written to disk (${xmlSize.toLocaleString()} bytes)`)
 
     return Object.assign(ctx, {mpackageFile})
+  }
+
+  #recordBuildStamp = async ctx => {
+    const {projectDirectory, built} = ctx
+
+    const buildDirectory = projectDirectory.getDirectory("build")
+    const buildStampFile = buildDirectory.getFile(".built")
+
+    if(await buildStampFile.exists)
+      await buildStampFile.delete()
+
+    await buildStampFile.write(`${built}\n`)
+
+    return ctx
   }
 
   #writeOutputFile = async ctx => {


### PR DESCRIPTION
This pull request bumps the version from 1.3.0 to 1.4.0 and adds build timestamp tracking functionality. The build process now records a timestamp when the package is created and writes this timestamp to a `.built` file in the build directory. The timestamp is captured during config.lua generation and used both in the configuration file and for the build stamp record.