### PR TITLE
Bump version to 1.4.1 and add title field support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"

--- a/src/modules/Mfile.js
+++ b/src/modules/Mfile.js
@@ -11,6 +11,7 @@ Mfile.MFILE_TO_CONFIG = Object.freeze(new Map([
   ["icon", "icon"],
   ["description", "description"],
   ["version", "version"],
+  ["title", "title"],
 ]))
 
 export default Mfile


### PR DESCRIPTION
This pull request bumps the version to 1.4.1 and adds support for a "title" field mapping in the Mfile configuration system. The new mapping allows the "title" property to be processed when converting Mfile data to configuration objects.