### PR TITLE
Bump version to 1.5.0 and add module creation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ Which is exactly how everybody likes their sex, yes? Yes. Okay.
 
 ## Features unique to muddy
 
+### Add modules
+
+muddy can scaffold new modules directly from the command line using `--add`.
+This creates the type directory (if needed), adds an entry to the `{type}.json`
+with all available fields from the schema pre-filled, and creates an empty
+`.lua` file — ready for you to fill in.
+
+```shell
+# Add a named script
+muddy . --add script --name "My Script"
+
+# Add an alias with auto-generated temp name (new_alias_1, new_alias_2, ...)
+muddy . --add alias
+
+# Short form
+muddy . -a trigger --name "Health Warning"
+```
+
+Valid types: `alias`, `key`, `script`, `timer`, `trigger`.
+
 ### Ignore patterns
 
 muddy supports an `ignore` field in your `mfile` that lets you exclude files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "1.4.1",
+  "version": "1.5.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"

--- a/src/Add.js
+++ b/src/Add.js
@@ -44,8 +44,22 @@ export default class Add {
     const resolvedName = name || this.#tempName(type, entries)
     const safeName = resolvedName.replaceAll(/[^\w]/g, "_").replace(/^\d+/, "")
 
+    if(!safeName) {
+      glog.error(`Module name '${resolvedName}' produces an empty filename after sanitization.`)
+      process.exit(1)
+    }
+
     if(entries.some(e => e.name === resolvedName)) {
       glog.error(`A ${type} named '${resolvedName}' already exists in ${jsonFile.relativeTo(cwd)}.`)
+      process.exit(1)
+    }
+
+    const luaFile = typeDir.getFile(`${safeName}.lua`)
+    if(await luaFile.exists) {
+      glog.error(
+        `A .lua file '${luaFile.relativeTo(cwd)}' already exists`
+        + ` (name '${resolvedName}' sanitizes to '${safeName}.lua').`
+      )
       process.exit(1)
     }
 
@@ -55,11 +69,8 @@ export default class Add {
     await jsonFile.write(JSON.stringify(entries, null, 2) + "\n")
     glog.success(c`Added {${plural}}${resolvedName}{/} to ${jsonFile.relativeTo(cwd)}`)
 
-    const luaFile = typeDir.getFile(`${safeName}.lua`)
-    if(!await luaFile.exists) {
-      await luaFile.write("")
-      glog.success(c`Created {${plural}}${luaFile.relativeTo(cwd)}{/}`)
-    }
+    await luaFile.write("")
+    glog.success(c`Created {${plural}}${luaFile.relativeTo(cwd)}{/}`)
   }
 
   /**

--- a/src/Add.js
+++ b/src/Add.js
@@ -1,0 +1,144 @@
+import c from "@gesslar/colours"
+import {DirectoryObject} from "@gesslar/toolkit"
+
+import Type from "./Type.js"
+
+/**
+ * Handles adding new Mudlet modules (scripts, aliases, triggers, etc.)
+ * to an existing muddy project.
+ */
+export default class Add {
+  /**
+   * Run the add command.
+   *
+   * @param {DirectoryObject} cwd - The project directory.
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger instance.
+   * @param {string} type - The singular module type (alias, key, script, timer, trigger).
+   * @param {string} [name] - Optional name for the new module.
+   * @returns {Promise<void>}
+   */
+  async run(cwd, glog, type, name) {
+    const plural = Type.TO_PLURAL[type]
+    if(!plural) {
+      glog.error(`Unknown type '${type}'. Valid types: ${Type.SINGLE.join(", ")}`)
+      process.exit(1)
+    }
+
+    const srcDir = cwd.getDirectory("src")
+    if(!await srcDir.exists) {
+      glog.error(`No 'src/' directory found in '${cwd.path}'.`)
+      process.exit(1)
+    }
+
+    const typeDir = srcDir.getDirectory(plural)
+    await typeDir.assureExists({recursive: true})
+
+    const jsonFileName = Type.FILES[plural]
+    const jsonFile = typeDir.getFile(jsonFileName)
+
+    let entries = []
+    if(await jsonFile.exists) {
+      entries = await jsonFile.loadData()
+    }
+
+    const resolvedName = name || this.#tempName(type, entries)
+    const safeName = resolvedName.replaceAll(/[^\w]/g, "_").replace(/^\d+/, "")
+
+    if(entries.some(e => e.name === resolvedName)) {
+      glog.error(`A ${type} named '${resolvedName}' already exists in ${jsonFile.relativeTo(cwd)}.`)
+      process.exit(1)
+    }
+
+    const entry = this.#defaultEntry(type, resolvedName)
+    entries.push(entry)
+
+    await jsonFile.write(JSON.stringify(entries, null, 2) + "\n")
+    glog.success(c`Added {${plural}}${resolvedName}{/} to ${jsonFile.relativeTo(cwd)}`)
+
+    const luaFile = typeDir.getFile(`${safeName}.lua`)
+    if(!await luaFile.exists) {
+      await luaFile.write("")
+      glog.success(c`Created {${plural}}${luaFile.relativeTo(cwd)}{/}`)
+    }
+  }
+
+  /**
+   * Generate a temporary name that doesn't conflict with existing entries.
+   *
+   * @param {string} type - The singular module type.
+   * @param {Array<object>} entries - Existing entries.
+   * @returns {string}
+   */
+  #tempName(type, entries) {
+    const names = new Set(entries.map(e => e.name))
+    let i = 1
+
+    while(names.has(`new_${type}_${i}`)) {
+      i++
+    }
+
+    return `new_${type}_${i}`
+  }
+
+  /**
+   * Create a default JSON entry for the given type, shaped
+   * according to the muddler JSON schemas so users can see
+   * all available fields.
+   *
+   * @param {string} type - The singular module type.
+   * @param {string} name - The module name.
+   * @returns {object}
+   */
+  #defaultEntry(type, name) {
+    const base = {
+      name,
+      isActive: "yes",
+      isFolder: "no",
+    }
+
+    switch(type) {
+      case "script":
+        return {
+          ...base,
+          eventHandlerList: [],
+        }
+      case "alias":
+        return {
+          ...base,
+          regex: "",
+          command: "",
+        }
+      case "trigger":
+        return {
+          ...base,
+          patterns: [
+            {pattern: "", type: "substring"},
+          ],
+          multiline: "no",
+          multilineDelta: "0",
+          matchall: "no",
+          filter: "no",
+          fireLength: "0",
+          highlight: "no",
+          highlightFG: "",
+          highlightBG: "",
+          soundFile: "",
+          command: "",
+        }
+      case "timer":
+        return {
+          ...base,
+          command: "",
+          time: "00:00:00.000",
+        }
+      case "key":
+        return {
+          ...base,
+          command: "",
+          keys: "",
+        }
+      default:
+        return base
+    }
+  }
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,8 +5,10 @@ import {Collection, DirectoryObject, FileObject, Glog, Sass, Term} from "@gessla
 import {Command} from "commander"
 import process from "node:process"
 
+import Add from "./Add.js"
 import Generate from "./Generate.js"
 import Muddy from "./Muddy.js"
+import Type from "./Type.js"
 import Watch from "./Watch.js"
 
 const aliasNames  = ["OK", "INFO", "WARN", "ERR"]
@@ -45,6 +47,11 @@ void (async() => {
       .option("-w, --watch", "Enable watch mode.", false)
       .option("-n, --nerd", "Nerd mode. Advanced error reporting.", false)
       .option("-m, --mfile <path>", "Path to an alternate mfile.")
+      .option(
+        `-a, --add <type>`,
+        `Add a new module of the given type (${Type.SINGLE.join(", ")}).`
+      )
+      .option("--name <name>", "Name for the new module (used with --add).")
       .parse()
 
     Object.assign(opts, program.opts())
@@ -56,6 +63,12 @@ void (async() => {
     if(!await cwd.exists) {
       glog.error(`No such directory '${dirArg}'.`)
       process.exit(1)
+    }
+
+    if(opts.add) {
+      await new Add().run(cwd, glog, opts.add, opts.name)
+
+      return
     }
 
     if(opts.generate) {

--- a/test/unit/add.test.js
+++ b/test/unit/add.test.js
@@ -197,6 +197,31 @@ describe("add command", () => {
     })
   })
 
+  describe("lua filename collision", () => {
+    let projectDir
+
+    before(async() => {
+      projectDir = await scaffold(
+        path.join(tmpDir, "luacollide")
+      )
+      await add(projectDir, "script", "My Script")
+    })
+
+    it("should reject a name that sanitizes to an existing lua file", async() => {
+      const {code} = await add(
+        projectDir, "script", "My_Script"
+      )
+      assert.notEqual(code, 0, "should exit with error")
+    })
+
+    it("should not add the colliding entry to the json", async() => {
+      const defs = await readJSON(path.join(
+        projectDir, "src", "scripts", "scripts.json"
+      ))
+      assert.equal(defs.length, 1, "should still have only one entry")
+    })
+  })
+
   describe("unknown type", () => {
     it("should reject an invalid type", async() => {
       const projectDir = await scaffold(

--- a/test/unit/add.test.js
+++ b/test/unit/add.test.js
@@ -1,0 +1,358 @@
+import {after, before, describe, it} from "node:test"
+import assert from "node:assert/strict"
+import {execFile} from "node:child_process"
+import {mkdir, readFile, rm, stat, writeFile} from "node:fs/promises"
+import {mkdtempSync} from "node:fs"
+import {promisify} from "node:util"
+import path from "node:path"
+import os from "node:os"
+import {fileURLToPath} from "node:url"
+
+const exec = promisify(execFile)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI = path.resolve(__dirname, "../../src/cli.js")
+
+/**
+ * Runs `muddy --add <type> [--name <name>] <dir>`.
+ *
+ * @param {string} dir - Project directory.
+ * @param {string} type - Module type.
+ * @param {string} [name] - Optional module name.
+ * @returns {Promise<{stdout: string, stderr: string, code: number}>}
+ */
+async function add(dir, type, name) {
+  const args = [CLI, dir, "--add", type]
+  if(name) args.push("--name", name)
+
+  try {
+    const {stdout, stderr} = await exec("node", args)
+
+    return {stdout, stderr, code: 0}
+  } catch(err) {
+    return {
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+      code: err.code ?? 1,
+    }
+  }
+}
+
+/**
+ * Checks whether a path exists.
+ *
+ * @param {string} filePath - Absolute path.
+ * @returns {Promise<boolean>}
+ */
+async function exists(filePath) {
+  try {
+    await stat(filePath)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Reads and parses a JSON file.
+ *
+ * @param {string} filePath - Absolute path.
+ * @returns {Promise<*>}
+ */
+async function readJSON(filePath) {
+  const raw = await readFile(filePath, "utf8")
+
+  return JSON.parse(raw)
+}
+
+/**
+ * Creates a minimal muddy project skeleton (src/ dir only).
+ *
+ * @param {string} base - Temp directory.
+ * @returns {Promise<string>} The project directory path.
+ */
+async function scaffold(base) {
+  const dir = path.join(base, "proj")
+  await mkdir(path.join(dir, "src"), {recursive: true})
+
+  return dir
+}
+
+describe("add command", () => {
+  let tmpDir
+
+  before(() => {
+    tmpDir = mkdtempSync(
+      path.join(os.tmpdir(), "muddy-add-")
+    )
+  })
+
+  after(async() => {
+    if(tmpDir) {
+      await rm(tmpDir, {recursive: true, force: true})
+    }
+  })
+
+  it("should appear in --help output", async() => {
+    const {stdout} = await exec("node", [CLI, "--help"])
+    assert.match(stdout, /-a, --add <type>/)
+  })
+
+  describe("adding with explicit name", () => {
+    let projectDir
+
+    before(async() => {
+      projectDir = await scaffold(tmpDir)
+    })
+
+    it("should create the type directory and json", async() => {
+      await add(projectDir, "script", "My Script")
+      const jsonPath = path.join(
+        projectDir, "src", "scripts", "scripts.json"
+      )
+      assert.ok(
+        await exists(jsonPath),
+        "scripts.json should be created"
+      )
+    })
+
+    it("should create a .lua file with sanitized name", async() => {
+      const luaPath = path.join(
+        projectDir, "src", "scripts", "My_Script.lua"
+      )
+      assert.ok(
+        await exists(luaPath),
+        "lua file should be created"
+      )
+    })
+
+    it("should write the correct entry shape for script", async() => {
+      const defs = await readJSON(path.join(
+        projectDir, "src", "scripts", "scripts.json"
+      ))
+      const entry = defs.find(e => e.name === "My Script")
+      assert.ok(entry, "entry should exist")
+      assert.equal(entry.isActive, "yes")
+      assert.equal(entry.isFolder, "no")
+      assert.ok(
+        Array.isArray(entry.eventHandlerList),
+        "should have eventHandlerList"
+      )
+    })
+  })
+
+  describe("adding with auto-generated name", () => {
+    let projectDir
+
+    before(async() => {
+      projectDir = await scaffold(
+        path.join(tmpDir, "auto")
+      )
+    })
+
+    it("should generate new_alias_1 as temp name", async() => {
+      await add(projectDir, "alias")
+      const defs = await readJSON(path.join(
+        projectDir, "src", "aliases", "aliases.json"
+      ))
+      assert.equal(defs[0].name, "new_alias_1")
+    })
+
+    it("should increment temp name on second add", async() => {
+      await add(projectDir, "alias")
+      const defs = await readJSON(path.join(
+        projectDir, "src", "aliases", "aliases.json"
+      ))
+      assert.equal(defs.length, 2)
+      assert.equal(defs[1].name, "new_alias_2")
+    })
+  })
+
+  describe("duplicate detection", () => {
+    let projectDir
+
+    before(async() => {
+      projectDir = await scaffold(
+        path.join(tmpDir, "dup")
+      )
+      await add(projectDir, "timer", "My Timer")
+    })
+
+    it("should reject adding a duplicate name", async() => {
+      const {code} = await add(
+        projectDir, "timer", "My Timer"
+      )
+      assert.notEqual(code, 0, "should exit with error")
+    })
+
+    it("should not add a second entry", async() => {
+      const defs = await readJSON(path.join(
+        projectDir, "src", "timers", "timers.json"
+      ))
+      assert.equal(
+        defs.filter(e => e.name === "My Timer").length,
+        1,
+        "should have exactly one entry"
+      )
+    })
+  })
+
+  describe("unknown type", () => {
+    it("should reject an invalid type", async() => {
+      const projectDir = await scaffold(
+        path.join(tmpDir, "badtype")
+      )
+      const {code} = await add(projectDir, "bogus")
+      assert.notEqual(code, 0)
+    })
+  })
+
+  describe("missing src directory", () => {
+    it("should fail when src/ does not exist", async() => {
+      const bare = path.join(tmpDir, "nosrc")
+      await mkdir(bare, {recursive: true})
+      const {code} = await add(bare, "script")
+      assert.notEqual(code, 0)
+    })
+  })
+
+  describe("appending to existing json", () => {
+    let projectDir
+
+    before(async() => {
+      projectDir = await scaffold(
+        path.join(tmpDir, "existing")
+      )
+      const typePath = path.join(
+        projectDir, "src", "keys"
+      )
+      await mkdir(typePath, {recursive: true})
+      await writeFile(
+        path.join(typePath, "keys.json"),
+        JSON.stringify([
+          {name: "Existing", keys: "f1"},
+        ], null, 2) + "\n"
+      )
+    })
+
+    it("should append without clobbering existing entries", async() => {
+      await add(projectDir, "key", "New Key")
+      const defs = await readJSON(path.join(
+        projectDir, "src", "keys", "keys.json"
+      ))
+      assert.equal(defs.length, 2)
+      assert.equal(defs[0].name, "Existing")
+      assert.equal(defs[0].keys, "f1")
+      assert.equal(defs[1].name, "New Key")
+    })
+  })
+
+  describe("schema-shaped entries for each type", () => {
+    let projectDir
+
+    before(async() => {
+      projectDir = await scaffold(
+        path.join(tmpDir, "shapes")
+      )
+      await add(projectDir, "alias", "a1")
+      await add(projectDir, "trigger", "t1")
+      await add(projectDir, "timer", "tm1")
+      await add(projectDir, "key", "k1")
+      await add(projectDir, "script", "s1")
+    })
+
+    it("alias should have regex and command fields", async() => {
+      const defs = await readJSON(path.join(
+        projectDir, "src", "aliases", "aliases.json"
+      ))
+      const e = defs[0]
+      assert.ok("regex" in e, "should have regex")
+      assert.ok("command" in e, "should have command")
+    })
+
+    it("trigger should have full schema shape", async() => {
+      const defs = await readJSON(path.join(
+        projectDir, "src", "triggers", "triggers.json"
+      ))
+      const e = defs[0]
+      assert.ok(
+        Array.isArray(e.patterns),
+        "should have patterns array"
+      )
+      assert.ok(
+        e.patterns.length > 0,
+        "should have a starter pattern"
+      )
+      assert.ok("type" in e.patterns[0], "pattern should have type")
+      assert.ok("multiline" in e, "should have multiline")
+      assert.ok("multilineDelta" in e, "should have multilineDelta")
+      assert.ok("matchall" in e, "should have matchall")
+      assert.ok("filter" in e, "should have filter")
+      assert.ok("fireLength" in e, "should have fireLength")
+      assert.ok("highlight" in e, "should have highlight")
+      assert.ok("highlightFG" in e, "should have highlightFG")
+      assert.ok("highlightBG" in e, "should have highlightBG")
+      assert.ok("soundFile" in e, "should have soundFile")
+      assert.ok("command" in e, "should have command")
+    })
+
+    it("timer should have command and time fields", async() => {
+      const defs = await readJSON(path.join(
+        projectDir, "src", "timers", "timers.json"
+      ))
+      const e = defs[0]
+      assert.ok("command" in e, "should have command")
+      assert.ok("time" in e, "should have time")
+      assert.match(
+        e.time, /^\d{2}:\d{2}:\d{2}\.\d{3}$/,
+        "time should match hh:mm:ss.mmm format"
+      )
+    })
+
+    it("key should have command and keys fields", async() => {
+      const defs = await readJSON(path.join(
+        projectDir, "src", "keys", "keys.json"
+      ))
+      const e = defs[0]
+      assert.ok("command" in e, "should have command")
+      assert.ok("keys" in e, "should have keys")
+    })
+
+    it("script should have eventHandlerList", async() => {
+      const defs = await readJSON(path.join(
+        projectDir, "src", "scripts", "scripts.json"
+      ))
+      const e = defs[0]
+      assert.ok(
+        Array.isArray(e.eventHandlerList),
+        "should have eventHandlerList array"
+      )
+    })
+
+    it("all types should have common base fields", async() => {
+      const types = [
+        ["aliases", "aliases.json"],
+        ["triggers", "triggers.json"],
+        ["timers", "timers.json"],
+        ["keys", "keys.json"],
+        ["scripts", "scripts.json"],
+      ]
+
+      for(const [dir, file] of types) {
+        const defs = await readJSON(path.join(
+          projectDir, "src", dir, file
+        ))
+        const e = defs[0]
+        assert.ok("name" in e, `${dir}: should have name`)
+        assert.equal(
+          e.isActive, "yes",
+          `${dir}: isActive should default to yes`
+        )
+        assert.equal(
+          e.isFolder, "no",
+          `${dir}: isFolder should default to no`
+        )
+      }
+    })
+  })
+})


### PR DESCRIPTION
This pull request adds a new `--add` command to the muddy CLI that allows users to create new Mudlet modules (scripts, aliases, triggers, timers, and keys) in existing projects.

## New Features

- **Add Command**: New `--add <type>` flag accepts module types: `script`, `alias`, `trigger`, `timer`, `key`
- **Optional Naming**: `--name <name>` flag allows specifying custom module names, otherwise auto-generates names like `new_script_1`
- **Smart File Creation**: Creates both JSON definition entries and corresponding `.lua` files with sanitized filenames
- **Schema-Compliant Entries**: Generates properly structured JSON entries with all required fields for each module type
- **Duplicate Prevention**: Validates that module names are unique within their type
- **Incremental Naming**: Auto-generated names increment to avoid conflicts

## Implementation Details

- Adds `Add.js` class to handle module creation logic
- Adds `Type.js` for type validation and mapping between singular/plural forms
- Integrates with existing CLI structure in `cli.js`
- Comprehensive test coverage in `test/unit/add.test.js` with 358 lines of tests
- Version bump from 1.4.1 to 1.5.0

The command creates the appropriate directory structure under `src/` and appends to existing JSON files without overwriting existing entries.