### PR TITLE
...

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ or empty, all files are included as usual.
 
 ## License
 
-`@gesslar/muddy` is released into the public domain under the [0BSD](LICENSE.txt).
+`@gesslar/muddy` is released under the [0BSD](LICENSE.txt).
 
 This package includes or depends on third-party components under their own
 licenses:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a single documentation fix in `README.md`, removing the phrase "into the public domain" from the license statement. The original text stated the package was "released into the public domain under the [0BSD]", which was slightly contradictory (something released into the public domain doesn't need a license; 0BSD is a license, not public domain). The corrected text simply states it is "released under the [0BSD]", which is more accurate.

- Removes the technically imprecise phrase "into the public domain" from the license description in `README.md`

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a single-line documentation correction with no functional impact.

The change is a minor wording fix to the README license statement, making it more precise. No code is modified, no logic is affected, and the correction is technically accurate.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["..."](https://github.com/gesslar/muddy/commit/d061e53de34e51e12f8a900f806f4655750640cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27957418)</sub>

<!-- /greptile_comment -->