### PR TITLE
Bump version to 2.2.0 and add version management subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,29 +37,14 @@ The only difference between invoking **muddy** over **muddler** is the cli.
 ## Immediate Invocation
 
 ```shell
-# npm
-npx @gesslar/muddy --help
-
-# npm
 npx @gesslar/muddy --help
 ```
 
 ## Install as a dependency, if you want, you don't have to
 
 ```shell
-# npm
-npm add -d @gesslar/muddy
-
-# npm
 npm i -d @gesslar/muddy
 ```
-
-## Post Hocktuah
-
-Also, shout out to [@Edru2](https://github.com/Edru2) for
-[DeMuddler](https://github.com/Edru2/DeMuddler) which is just sex on a stick.
-
-Which is exactly how everybody likes their sex, yes? Yes. Okay.
 
 ## Features unique to muddy
 
@@ -109,6 +94,28 @@ Patterns are matched against relative paths within `src/`. They apply to:
 Standard glob syntax is supported (e.g. `*`, `**`, `?`). If `ignore` is omitted
 or empty, all files are included as usual.
 
+### Version management
+
+muddy can bump, print, or set the semantic version in your `mfile` directly,
+without the clean-tree-and-commit requirements of `npm version`.
+
+```shell
+# Bump
+muddy version patch          # 1.2.3 -> 1.2.4
+muddy version minor          # 1.2.3 -> 1.3.0
+muddy version major          # 1.2.3 -> 2.0.0
+
+# Print the current version (plain stdout — friendly to $(…) capture)
+muddy version current
+
+# Set explicitly
+muddy version set 4.5.6
+```
+
+The mfile is rewritten in place via a targeted regex, so existing formatting
+(quote style, spacing, key order) is preserved. No git commit or tag is
+created — that's left entirely up to you.
+
 ## License
 
 `@gesslar/muddy` is released under the [0BSD](LICENSE.txt).
@@ -124,6 +131,13 @@ licenses:
 | [adm-zip](https://github.com/cthackers/adm-zip) | MIT |
 | [commander](https://github.com/tj/commander.js) | MIT |
 | [xmlbuilder2](https://github.com/oozcitak/xmlbuilder2) | MIT |
+
+## Post Hocktuah
+
+Also, shout out to [@Edru2](https://github.com/Edru2) for
+[DeMuddler](https://github.com/Edru2/DeMuddler) which is just sex on a stick.
+
+Which is exactly how everybody likes their sex, yes? Yes. Okay.
 
 ## Postmate
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@gesslar/actioneer": "^3.0.1",
         "@gesslar/colours": "^1.0.0",
-        "@gesslar/toolkit": "^5.1.0",
+        "@gesslar/toolkit": "^5.4.0",
         "adm-zip": "^0.5.17",
         "commander": "^14.0.3",
         "xmlbuilder2": "^4.0.3"
@@ -22,11 +22,11 @@
       "devDependencies": {
         "@gesslar/uglier": "^2.4.1",
         "console-ninja": "^1.0.0",
-        "eslint": "^10.2.0",
-        "typescript": "^6.0.2"
+        "eslint": "^10.3.0",
+        "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=v24.11.0"
+        "node": ">=v24"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -195,17 +195,17 @@
       }
     },
     "node_modules/@gesslar/toolkit": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.2.0.tgz",
-      "integrity": "sha512-1QP/zPW8a/CvdJljrG8MDVm+CMUzgUNzSOGHKSN8bsIEKoBnGEx8xKK4E+U1NxadAw7CeeOJQMgBIb1CrPPRDw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@gesslar/toolkit/-/toolkit-5.4.0.tgz",
+      "integrity": "sha512-hfSURWq/R2vrCTNy+qbLAm7fhr9l8BJqhUjmB6FtZHqmANHtYX47OxTgi04FQ4n/26TkQkkZCUFANliobSLBCw==",
       "hasInstallScript": true,
       "license": "0BSD",
       "dependencies": {
         "@gesslar/colours": "^1.0.0",
-        "ajv": "^8.18.0",
+        "ajv": "^8.20.0",
         "json5": "^2.2.3",
         "supports-color": "^10.2.2",
-        "yaml": "^2.8.3"
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=24"
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -661,9 +661,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1794,9 +1794,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2008,9 +2008,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "0BSD",
   "engines": {
-    "node": ">=v24.11.0"
+    "node": ">=24"
   },
   "icon": "mud-128.png",
   "homepage": "https://github.com/gesslar/muddy",
@@ -50,11 +50,11 @@
     "minor": "npm version minor",
     "major": "npm version major"
   },
-  "packageManager": "npm@11.12.1",
+  "packageManager": "npm@11.14.1",
   "dependencies": {
     "@gesslar/actioneer": "^3.0.1",
     "@gesslar/colours": "^1.0.0",
-    "@gesslar/toolkit": "^5.1.0",
+    "@gesslar/toolkit": "^5.4.0",
     "adm-zip": "^0.5.17",
     "commander": "^14.0.3",
     "xmlbuilder2": "^4.0.3"
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@gesslar/uglier": "^2.4.1",
     "console-ninja": "^1.0.0",
-    "eslint": "^10.2.0",
-    "typescript": "^6.0.2"
+    "eslint": "^10.3.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "2.1.0",
+  "version": "2.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"

--- a/src/Version.js
+++ b/src/Version.js
@@ -43,7 +43,7 @@ export default class Version {
 
     // Regex-replace rather than parse + re-emit, so the file's existing
     // formatting (quote style, spacing, key order, trailing commas) is preserved.
-    const versionRegex = /("version"\s*:\s*)(["'])[^"'\n]*\2/
+    const versionRegex = /^(\s*"version"\s*:\s*)(["'])[^"'\n]*\2/m
 
     Valid.assert(versionRegex.test(mfileRaw), `Could not locate "version" key in ${mfile}`)
 

--- a/src/Version.js
+++ b/src/Version.js
@@ -1,0 +1,115 @@
+import {DirectoryObject, Sass, Util, Valid} from "@gesslar/toolkit"
+
+/**
+ * Reads, bumps, and sets the SemVer in a project's mfile, in place.
+ */
+export default class Version {
+  /**
+   * Locate the mfile in the current working directory and pull its current
+   * version. Throws if either the file or the version field is missing.
+   *
+   * @returns {Promise<{mfile: import("@gesslar/toolkit").FileObject, version: string}>}
+   * @private
+   */
+  static async #loadMfile() {
+    const cwd = DirectoryObject.fromCwd()
+    const mfile = cwd.getFile("mfile")
+
+    if(!await mfile.exists)
+      throw Sass.new(`No such file ${mfile}`)
+
+    const data = await mfile.loadData()
+    const version = data?.version
+
+    if(!version)
+      throw Sass.new(`No SemVer information in ${mfile}`)
+
+    return {mfile, version}
+  }
+
+  /**
+   * Rewrite the "version" value in the mfile via regex, preserving the rest
+   * of the file's formatting byte-for-byte.
+   *
+   * @param {import("@gesslar/toolkit").FileObject} mfile - The mfile to update.
+   * @param {string} oldVersion - The current version (for the log message).
+   * @param {string} newVersion - The version to write.
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger instance.
+   * @returns {Promise<void>}
+   * @private
+   */
+  static async #writeVersion(mfile, oldVersion, newVersion, glog) {
+    const mfileRaw = await mfile.read()
+
+    // Regex-replace rather than parse + re-emit, so the file's existing
+    // formatting (quote style, spacing, key order, trailing commas) is preserved.
+    const versionRegex = /("version"\s*:\s*)(["'])[^"'\n]*\2/
+
+    Valid.assert(versionRegex.test(mfileRaw), `Could not locate "version" key in ${mfile}`)
+
+    const newMfileRaw = mfileRaw.replace(versionRegex, `$1$2${newVersion}$2`)
+
+    await mfile.write(newMfileRaw)
+
+    glog.success(`${mfile} updated from ${oldVersion} => ${newVersion}`)
+  }
+
+  /**
+   * Increment the SemVer in the current directory's mfile and write it back.
+   *
+   * @param {"major"|"minor"|"patch"} kind - Which component to bump.
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger instance.
+   * @returns {Promise<void>}
+   */
+  static async increment(kind, glog) {
+    const {mfile, version} = await this.#loadMfile()
+
+    glog.info(`Found ${mfile}`)
+
+    let {major, minor, patch} = Util.semver.basic.exec(version)?.groups ?? {}
+
+    Valid.assert(Boolean(minor && major && patch), `Invalid SemVer format '${version}'`)
+
+    if(kind === "patch") {
+      patch = (Number(patch) + 1).toString()
+    } else if(kind === "minor") {
+      minor = (Number(minor) + 1).toString()
+      patch = "0"
+    } else if(kind === "major") {
+      major = (Number(major) + 1).toString()
+      minor = "0"
+      patch = "0"
+    }
+
+    const newVersion = `${major}.${minor}.${patch}`
+
+    await this.#writeVersion(mfile, version, newVersion, glog)
+  }
+
+  /**
+   * Print the current SemVer from the mfile to stdout. Plain output (no log
+   * prefix) so it's friendly to shell capture: VERSION=$(muddy version current)
+   *
+   * @returns {Promise<void>}
+   */
+  static async current() {
+    const {version} = await this.#loadMfile()
+
+    console.log(version)
+  }
+
+  /**
+   * Set the mfile's version to an explicit SemVer.
+   *
+   * @param {string} newVersion - The SemVer to write (must be basic x.y.z form).
+   * @param {import("@gesslar/toolkit").Glog} glog - Logger instance.
+   * @returns {Promise<void>}
+   */
+  static async set(newVersion, glog) {
+    Valid.assert(Util.semver.basic.test(newVersion), `Invalid SemVer format '${newVersion}'`)
+
+    const {mfile, version} = await this.#loadMfile()
+
+    await this.#writeVersion(mfile, version, newVersion, glog)
+  }
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,7 @@
 
 import c from "@gesslar/colours"
 import {Collection, DirectoryObject, FileObject, Glog, Sass, Term} from "@gesslar/toolkit"
-import {Command} from "commander"
+import {Argument, Command} from "commander"
 import process from "node:process"
 
 import Add from "./Add.js"
@@ -10,6 +10,7 @@ import Generate from "./Generate.js"
 import Muddy from "./Muddy.js"
 import Type from "./Type.js"
 import Watch from "./Watch.js"
+import Version from "./Version.js"
 
 const aliasNames  = ["OK", "INFO", "WARN", "ERR"]
 const aliasCodes  = ["{<I}{F064}", "{<I}{F023}", "{<I}{F178}", "{<I}{F166}"]
@@ -20,7 +21,7 @@ const glogColourNames   = ["success", "info", "warn", "error"]
 const glogColourCodes   = ["{F035}", "{F033}", "{F208}", "{F032}"]
 
 void (async() => {
-  const opts = {}, args = []
+  const opts = {}
 
   try {
     // Initialize colours aliases
@@ -42,6 +43,8 @@ void (async() => {
       ))
 
     const program = new Command("muddy")
+
+    program
       .argument("[directory]", "The project directory containing an 'mfile' file and 'src/' directory.")
       .option("-g, --generate", "Generate a new muddy project skeleton.", false)
       .option("-w, --watch", "Enable watch mode.", false)
@@ -52,76 +55,112 @@ void (async() => {
         `Add a new module of the given type (${Type.SINGLE.join(", ")}).`
       )
       .option("--name <name>", "Name for the new module (used with --add).")
-      .parse()
+      .action(muddy)
 
-    Object.assign(opts, program.opts())
-    args.push(...program.args)
+    const versionCmd = program
+      .command("version")
+      .description("Increment the semantic version (major, minor, or patch)")
+      .addArgument(new Argument("<kind>").choices(["major", "minor", "patch"]))
+      .action(incrementVersion)
 
-    const dirArg = args.join(" ").trim()
-    const cwd = new DirectoryObject(dirArg || ".")
+    versionCmd
+      .command("current")
+      .description("Print the current semantic version")
+      .action(currentVersion)
 
-    if(!await cwd.exists) {
-      glog.error(`No such directory '${dirArg}'.`)
-      process.exit(1)
-    }
+    versionCmd
+      .command("set")
+      .description("Set the semantic version to an explicit x.y.z value")
+      .addArgument(new Argument("<semver>"))
+      .action(setVersion)
 
-    if(opts.add) {
-      await new Add().run(cwd, glog, opts.add, opts.name)
+    await program.parseAsync()
 
-      return
-    }
+    async function muddy(directory, options) {
+      Object.assign(opts, options)
 
-    if(opts.generate) {
-      await new Generate().run(cwd, glog)
+      const dirArg = directory?.trim() ?? ""
+      const cwd = new DirectoryObject(dirArg || ".")
 
-      return
-    }
-
-    let mfileObject = null
-
-    if(opts.mfile) {
-      mfileObject = new FileObject(opts.mfile, cwd)
-
-      if(!await mfileObject.exists) {
-        glog.error(`No such mfile '${opts.mfile}'.`)
+      if(!await cwd.exists) {
+        glog.error(`No such directory '${dirArg}'.`)
         process.exit(1)
       }
 
-      if(!await cwd.hasDirectory("src")) {
-        glog.error(`'${cwd.path}' is not a valid muddy project directory.`)
-        process.exit(1)
+      if(opts.add) {
+        await new Add().run(cwd, glog, opts.add, opts.name)
+
+        return
       }
-    } else {
-      if(!(await cwd.hasDirectory("src") && await cwd.hasFile("mfile"))) {
-        glog.error(`'${cwd.path}' is not a valid muddy project directory.`)
-        process.exit(1)
+
+      if(opts.generate) {
+        await new Generate().run(cwd, glog)
+
+        return
+      }
+
+      let mfileObject = null
+
+      if(opts.mfile) {
+        mfileObject = new FileObject(opts.mfile, cwd)
+
+        if(!await mfileObject.exists) {
+          glog.error(`No such mfile '${opts.mfile}'.`)
+          process.exit(1)
+        }
+
+        if(!await cwd.hasDirectory("src")) {
+          glog.error(`'${cwd.path}' is not a valid muddy project directory.`)
+          process.exit(1)
+        }
+      } else {
+        if(!(await cwd.hasDirectory("src") && await cwd.hasFile("mfile"))) {
+          glog.error(`'${cwd.path}' is not a valid muddy project directory.`)
+          process.exit(1)
+        }
+      }
+
+      if(opts.watch) {
+        setupAbortHandlers()
+        await new Watch().run(cwd, glog, mfileObject)
+      } else {
+        await new Muddy().run(cwd, glog, mfileObject)
       }
     }
 
-    if(opts.watch) {
-      setupAbortHandlers()
-      await new Watch().run(cwd, glog, mfileObject)
-    } else {
-      await new Muddy().run(cwd, glog, mfileObject)
+    /**
+     * Creates handlers for various reasons that the application may crash.
+     */
+    function setupAbortHandlers() {
+      void["SIGINT", "SIGTERM", "SIGHUP"].forEach(signal => {
+        process.on(signal, () => {
+          Term
+            .setLineMode()
+            .showCursor()
+            .pause()
+
+          process.exit(0)
+        })
+      })
+    }
+
+    async function incrementVersion(kind) {
+      // Pull in root opts so global flags like --nerd surface to the catch below.
+      Object.assign(opts, program.opts())
+      await Version.increment(kind, glog)
+    }
+
+    async function currentVersion() {
+      Object.assign(opts, program.opts())
+      await Version.current()
+    }
+
+    async function setVersion(newVersion) {
+      Object.assign(opts, program.opts())
+      await Version.set(newVersion, glog)
     }
   } catch(error) {
     Sass.from(error, "Starting muddy.").report(opts.nerd ?? false)
-    process.exitCode = 1
-  }
-
-  /**
-   * Creates handlers for various reasons that the application may crash.
-   */
-  function setupAbortHandlers() {
-    void["SIGINT", "SIGTERM", "SIGHUP"].forEach(signal => {
-      process.on(signal, () => {
-        Term
-          .setLineMode()
-          .showCursor()
-          .pause()
-
-        process.exit(0)
-      })
-    })
+    process.exit(1)
   }
 })()

--- a/test/unit/Version.test.js
+++ b/test/unit/Version.test.js
@@ -1,0 +1,279 @@
+import {afterEach, beforeEach, describe, it} from "node:test"
+import assert from "node:assert/strict"
+import {execFile} from "node:child_process"
+import {mkdtemp, readFile, rm, writeFile} from "node:fs/promises"
+import {promisify} from "node:util"
+import path from "node:path"
+import os from "node:os"
+import {fileURLToPath} from "node:url"
+
+const exec = promisify(execFile)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI = path.resolve(__dirname, "../../src/cli.js")
+
+/**
+ * Runs the CLI in a given working directory and returns {stdout, stderr, code}.
+ *
+ * @param {string} cwd - Working directory for the CLI subprocess.
+ * @param {string[]} args - CLI arguments.
+ * @returns {Promise<{stdout: string, stderr: string, code: number|string}>}
+ */
+async function run(cwd, args) {
+  try {
+    const {stdout, stderr} = await exec("node", [CLI, ...args], {cwd})
+    return {stdout, stderr, code: 0}
+  } catch(err) {
+    return {stdout: err.stdout ?? "", stderr: err.stderr ?? "", code: err.code ?? 1}
+  }
+}
+
+/**
+ * Writes a minimal mfile with the given version into tmpDir.
+ *
+ * @param {string} tmpDir - Target directory.
+ * @param {string} version - Version string to embed.
+ * @returns {Promise<void>}
+ */
+async function writeMfile(tmpDir, version) {
+  const body = JSON.stringify({
+    package: "VersionTest",
+    version,
+    author: "Test"
+  }, null, 2) + "\n"
+
+  await writeFile(path.join(tmpDir, "mfile"), body)
+}
+
+describe("version subcommand", () => {
+  let tmpDir
+
+  beforeEach(async() => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "muddy-version-"))
+  })
+
+  afterEach(async() => {
+    await rm(tmpDir, {recursive: true, force: true})
+  })
+
+  describe("happy paths", () => {
+    it("bumps patch: 1.2.3 -> 1.2.4", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const {code} = await run(tmpDir, ["version", "patch"])
+      assert.equal(code, 0, "should exit cleanly")
+
+      const updated = JSON.parse(await readFile(path.join(tmpDir, "mfile"), "utf8"))
+      assert.equal(updated.version, "1.2.4")
+    })
+
+    it("bumps minor: 1.2.3 -> 1.3.0 (resets patch)", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const {code} = await run(tmpDir, ["version", "minor"])
+      assert.equal(code, 0)
+
+      const updated = JSON.parse(await readFile(path.join(tmpDir, "mfile"), "utf8"))
+      assert.equal(updated.version, "1.3.0")
+    })
+
+    it("bumps major: 1.2.3 -> 2.0.0 (resets minor and patch)", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const {code} = await run(tmpDir, ["version", "major"])
+      assert.equal(code, 0)
+
+      const updated = JSON.parse(await readFile(path.join(tmpDir, "mfile"), "utf8"))
+      assert.equal(updated.version, "2.0.0")
+    })
+
+    it("handles zero components: 0.0.9 -> 0.0.10 (patch)", async() => {
+      await writeMfile(tmpDir, "0.0.9")
+
+      const {code} = await run(tmpDir, ["version", "patch"])
+      assert.equal(code, 0)
+
+      const updated = JSON.parse(await readFile(path.join(tmpDir, "mfile"), "utf8"))
+      assert.equal(updated.version, "0.0.10")
+    })
+
+    it("preserves surrounding file formatting", async() => {
+      // Deliberately quirky layout — tabs, extra spaces, ordering — to confirm
+      // the regex-based rewrite doesn't normalize anything but the version value.
+      const mfile = path.join(tmpDir, "mfile")
+      const original = `{\n    "package":     "VersionTest",\n  "version":  "1.2.3",\n\t"author":\t"Test"\n}\n`
+
+      await writeFile(mfile, original)
+
+      const {code} = await run(tmpDir, ["version", "patch"])
+      assert.equal(code, 0)
+
+      const updated = await readFile(mfile, "utf8")
+      assert.equal(updated, original.replace("1.2.3", "1.2.4"))
+    })
+
+    it("only rewrites the version key, not other version-looking values", async() => {
+      const mfile = path.join(tmpDir, "mfile")
+      const body = JSON.stringify({
+        package: "VersionTest",
+        version: "1.2.3",
+        notes: "Legacy 1.2.3 is also referenced here."
+      }, null, 2) + "\n"
+
+      await writeFile(mfile, body)
+
+      const {code} = await run(tmpDir, ["version", "patch"])
+      assert.equal(code, 0)
+
+      const updated = JSON.parse(await readFile(mfile, "utf8"))
+      assert.equal(updated.version, "1.2.4")
+      assert.equal(updated.notes, "Legacy 1.2.3 is also referenced here.")
+    })
+  })
+
+  describe("sad paths", () => {
+    it("fails when no mfile exists in cwd", async() => {
+      const {code} = await run(tmpDir, ["version", "patch"])
+      assert.notEqual(code, 0)
+    })
+
+    it("fails when mfile has no version field", async() => {
+      await writeFile(path.join(tmpDir, "mfile"), JSON.stringify({package: "X"}) + "\n")
+
+      const {code} = await run(tmpDir, ["version", "patch"])
+      assert.notEqual(code, 0)
+    })
+
+    it("fails when version is not a basic SemVer (e.g. '1.2')", async() => {
+      await writeMfile(tmpDir, "1.2")
+
+      const {code} = await run(tmpDir, ["version", "patch"])
+      assert.notEqual(code, 0)
+    })
+
+    it("fails when version has a leading-zero component", async() => {
+      // Util.semver.basic disallows leading zeros (e.g. '01.2.3').
+      await writeMfile(tmpDir, "01.2.3")
+
+      const {code} = await run(tmpDir, ["version", "patch"])
+      assert.notEqual(code, 0)
+    })
+
+    it("rejects an unknown kind argument", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const {code, stderr} = await run(tmpDir, ["version", "wibble"])
+      assert.notEqual(code, 0)
+      assert.match(stderr, /wibble|choice/i, "should mention the bad argument")
+    })
+
+    it("requires a kind argument", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const {code} = await run(tmpDir, ["version"])
+      assert.notEqual(code, 0)
+    })
+  })
+
+  describe("current subcommand", () => {
+    it("prints the current version on stdout", async() => {
+      await writeMfile(tmpDir, "3.14.15")
+
+      const {stdout, code} = await run(tmpDir, ["version", "current"])
+      assert.equal(code, 0)
+      assert.match(stdout, /^3\.14\.15\s*$/m, "should print bare version, no log prefix")
+    })
+
+    it("does not modify the mfile", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const before = await readFile(path.join(tmpDir, "mfile"), "utf8")
+
+      const {code} = await run(tmpDir, ["version", "current"])
+      assert.equal(code, 0)
+
+      const after = await readFile(path.join(tmpDir, "mfile"), "utf8")
+      assert.equal(after, before, "file should be byte-identical")
+    })
+
+    it("fails when no mfile exists in cwd", async() => {
+      const {code} = await run(tmpDir, ["version", "current"])
+      assert.notEqual(code, 0)
+    })
+
+    it("fails when mfile has no version field", async() => {
+      await writeFile(path.join(tmpDir, "mfile"), JSON.stringify({package: "X"}) + "\n")
+
+      const {code} = await run(tmpDir, ["version", "current"])
+      assert.notEqual(code, 0)
+    })
+  })
+
+  describe("set subcommand", () => {
+    it("sets the version to an explicit value", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const {code} = await run(tmpDir, ["version", "set", "4.5.6"])
+      assert.equal(code, 0)
+
+      const updated = JSON.parse(await readFile(path.join(tmpDir, "mfile"), "utf8"))
+      assert.equal(updated.version, "4.5.6")
+    })
+
+    it("permits setting to a lower version", async() => {
+      // No monotonicity check — explicit set is explicit.
+      await writeMfile(tmpDir, "5.0.0")
+
+      const {code} = await run(tmpDir, ["version", "set", "1.0.0"])
+      assert.equal(code, 0)
+
+      const updated = JSON.parse(await readFile(path.join(tmpDir, "mfile"), "utf8"))
+      assert.equal(updated.version, "1.0.0")
+    })
+
+    it("preserves surrounding file formatting", async() => {
+      const mfile = path.join(tmpDir, "mfile")
+      const original = `{\n    "package":     "VersionTest",\n  "version":  "1.2.3",\n\t"author":\t"Test"\n}\n`
+
+      await writeFile(mfile, original)
+
+      const {code} = await run(tmpDir, ["version", "set", "9.9.9"])
+      assert.equal(code, 0)
+
+      const updated = await readFile(mfile, "utf8")
+      assert.equal(updated, original.replace("1.2.3", "9.9.9"))
+    })
+
+    it("rejects a non-SemVer value", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const {code} = await run(tmpDir, ["version", "set", "wibble"])
+      assert.notEqual(code, 0)
+    })
+
+    it("rejects a partial SemVer (e.g. '1.2')", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const {code} = await run(tmpDir, ["version", "set", "1.2"])
+      assert.notEqual(code, 0)
+    })
+
+    it("rejects a SemVer with leading-zero component", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const {code} = await run(tmpDir, ["version", "set", "01.2.3"])
+      assert.notEqual(code, 0)
+    })
+
+    it("requires a value argument", async() => {
+      await writeMfile(tmpDir, "1.2.3")
+
+      const {code} = await run(tmpDir, ["version", "set"])
+      assert.notEqual(code, 0)
+    })
+
+    it("fails when no mfile exists in cwd", async() => {
+      const {code} = await run(tmpDir, ["version", "set", "1.0.0"])
+      assert.notEqual(code, 0)
+    })
+  })
+})


### PR DESCRIPTION
## Add `version` subcommand for mfile SemVer management

Introduces a `version` subcommand that lets you bump, print, or explicitly set the semantic version stored in your `mfile`, without the clean-tree-and-commit requirements of `npm version`.

### Usage

```shell
# Bump a component
muddy version patch          # 1.2.3 -> 1.2.4
muddy version minor          # 1.2.3 -> 1.3.0
muddy version major          # 1.2.3 -> 2.0.0

# Print the current version (plain stdout, friendly to $(...) capture)
muddy version current

# Set an explicit version
muddy version set 4.5.6
```

The mfile is rewritten in place using a targeted regex, so existing formatting — quote style, spacing, key order — is preserved byte-for-byte. No git commit or tag is created.

### Changes

- **`src/Version.js`** — New class with static `increment`, `current`, and `set` methods. Version reads and writes go through a shared `#loadMfile` / `#writeVersion` pair to keep file-handling consistent.
- **`src/cli.js`** — Registers the `version` command and its `current` and `set` subcommands via Commander. The default `muddy` action is now an inline named function, and `process.exit(1)` replaces `process.exitCode = 1` in the catch block so subcommand errors terminate cleanly.
- **`test/unit/Version.test.js`** — Full integration test suite covering happy paths (patch/minor/major bumps, formatting preservation, isolated key rewriting) and sad paths (missing mfile, missing version field, invalid SemVer, bad arguments) for all three subcommands.
- **`README.md`** — Documents the new `version` subcommand and moves the "Post Hocktuah" shoutout after the dependency table.
- Bumped to `2.2.0`, updated `@gesslar/toolkit` to `^5.4.0`, relaxed the Node engine requirement to `>=24`, and updated dev dependencies.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `version` subcommand to `muddy` that lets users bump, print, or explicitly set the SemVer stored in their `mfile`, without triggering `npm version`'s clean-tree-and-commit requirements. It also bumps the package to `2.2.0` and updates several dependencies.

- **`src/Version.js`** introduces a new class with static `increment`, `current`, and `set` methods; file reads and writes are centralized in private `#loadMfile` / `#writeVersion` helpers, and the rewrite uses a regex anchored with `^` + multiline flag so existing formatting is preserved byte-for-byte.
- **`src/cli.js`** registers the `version` command with Commander using a choices-constrained `<kind>` argument (for bumps) and nested `current` / `set` subcommands; `process.exit(1)` replaces `process.exitCode = 1` for immediate termination on error.
- **`test/unit/Version.test.js`** provides full integration coverage via subprocess execution, covering all three subcommands across happy and sad paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new Version class and CLI wiring are straightforward, well-guarded by Commander's argument validation, and backed by thorough integration tests.

The change is self-contained: a new class, CLI subcommand registration, and matching tests. The regex rewrite correctly anchors on ^ with the multiline flag, Commander's .choices() enforcement prevents invalid values from reaching the bump logic, and the #loadMfile / #writeVersion helpers fail fast and clearly on missing or malformed input.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Update src/Version.js"](https://github.com/gesslar/muddy/commit/c7807a2b3d6c6ee2320cb2378833c86af47aa73d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31903811)</sub>

<!-- /greptile_comment -->