### PR TITLE
Bump version to 2.2.1 and refactor watch debouncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 work/
 dist/
 test/fixtures/**/build/
+.claude/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.0.1",
@@ -26,7 +26,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=v24"
+        "node": ">=24"
       }
     },
     "node_modules/@astrojs/compiler": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "2.2.0",
+  "version": "2.2.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"

--- a/src/Watch.js
+++ b/src/Watch.js
@@ -1,8 +1,10 @@
-import {Disposer, Notify, Sass, Term, Time} from "@gesslar/toolkit"
+import {Disposer, Notify, Sass, Term} from "@gesslar/toolkit"
 import {watch} from "node:fs/promises"
 import process from "node:process"
 
 import Muddy from "./Muddy.js"
+
+const DEBOUNCE_MS = 250
 
 /**
  * @import {DirectoryObject} from "@gesslar/toolkit"
@@ -36,6 +38,8 @@ export default class Watch {
   #pending = false
   /** @type {boolean} */
   #busy = false
+  /** @type {ReturnType<typeof setTimeout>|null} */
+  #debounceTimer = null
 
   /**
    * Main execution point.
@@ -78,29 +82,7 @@ export default class Watch {
         ;(async() => {
           try {
             for await(const _ of watcher) {
-              if(this.#busy) {
-                this.#pending = true
-                continue
-              }
-
-              this.#pending = false
-              this.#busy = true
-
-              while(true) {
-                await Time.after(50)
-                await new Muddy().run(
-                  this.#projectDirectory, this.#glog, this.#mfileObject
-                )
-
-                if(this.#pending) {
-                  this.#pending = false
-                  continue
-                }
-
-                break
-              }
-
-              this.#busy = false
+              this.#scheduleRun()
             }
           } catch(err) {
             if(err.name === "AbortError")
@@ -111,6 +93,39 @@ export default class Watch {
         })()
       }
     } catch {}
+  }
+
+  #scheduleRun() {
+    if(this.#busy) {
+      this.#pending = true
+
+      return
+    }
+
+    if(this.#debounceTimer)
+      clearTimeout(this.#debounceTimer)
+
+    this.#debounceTimer = setTimeout(() => {
+      this.#debounceTimer = null
+      this.#runMuddy().catch(err => {
+        Sass.new("Build error during watch.", err).report(true)
+      })
+    }, DEBOUNCE_MS)
+  }
+
+  async #runMuddy() {
+    this.#busy = true
+
+    try {
+      do {
+        this.#pending = false
+        await new Muddy().run(
+          this.#projectDirectory, this.#glog, this.#mfileObject
+        )
+      } while(this.#pending)
+    } finally {
+      this.#busy = false
+    }
   }
 
   /**


### PR DESCRIPTION
## Refactor watch mode with debounced file change handling

Replaces the previous busy-loop approach in `Watch.js` with a proper debounce mechanism. File change events now schedule a delayed run via `#scheduleRun()`, which clears and resets a 250ms debounce timer before invoking `#runMuddy()`. This prevents redundant builds from rapid successive file system events and simplifies the control flow by separating scheduling logic from build execution.

The unused `Time` import has been removed, and the node engine version constraint has been corrected from `>=v24` to `>=24`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the version to 2.2.1 and replaces a busy-loop file-change handler in `Watch.js` with a cleaner debounce-based approach, while also removing the now-unused `Time` import and fixing the `engines.node` field format.

- **`src/Watch.js`**: The old tight `while(true)` loop with a 50ms `Time.after()` sleep is replaced by `#scheduleRun()` (debounce, 250ms) and `#runMuddy()` (async build runner with `do…while` for pending events); errors from the async build are now caught via `.catch()` and reported through `Sass`.
- **`package.json` / `package-lock.json`**: Version bumped to 2.2.1 and `"node": ">=v24"` corrected to `"node": ">=24"` — the leading `v` is not valid in npm's `engines` field.
- **`.gitignore`**: Added `.claude/` to exclude Claude Code local files from version control.

<h3>Confidence Score: 5/5</h3>

The refactor is safe to merge — the debounce logic is straightforward, error handling is now explicit, and the engine-field fix is a correct correction.

The new #scheduleRun / #runMuddy split is a clear improvement over the old busy-loop. Build errors are caught and reported rather than propagating unhandled. The do-while correctly re-runs when events arrive during a build. No new correctness issues introduced by the changed code.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["fixing debounce for Windows"](https://github.com/gesslar/muddy/commit/5f2d1aba662259af8fca5fd8d12a505bdb209b2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32076903)</sub>

<!-- /greptile_comment -->