### PR TITLE
Update dependencies and move README postscript sections before license

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ The mfile is rewritten in place via a targeted regex, so existing formatting
 (quote style, spacing, key order) is preserved. No git commit or tag is
 created — that's left entirely up to you.
 
+## Post Hocktuah
+
+Also, shout out to [@Edru2](https://github.com/Edru2) for
+[DeMuddler](https://github.com/Edru2/DeMuddler) which is just sex on a stick.
+
+Which is exactly how everybody likes their sex, yes? Yes. Okay.
+
+## Postmate
+
+_did you know there's a javascript.com?? I just found that out. holy shit._
+
 ## License
 
 `@gesslar/muddy` is released under the [0BSD](LICENSE.txt).
@@ -131,14 +142,3 @@ licenses:
 | [adm-zip](https://github.com/cthackers/adm-zip) | MIT |
 | [commander](https://github.com/tj/commander.js) | MIT |
 | [xmlbuilder2](https://github.com/oozcitak/xmlbuilder2) | MIT |
-
-## Post Hocktuah
-
-Also, shout out to [@Edru2](https://github.com/Edru2) for
-[DeMuddler](https://github.com/Edru2/DeMuddler) which is just sex on a stick.
-
-Which is exactly how everybody likes their sex, yes? Yes. Okay.
-
-## Postmate
-
-_did you know there's a javascript.com?? I just found that out. holy shit._

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # muddy
 
 <p align="center">
-  <img src="mud-128.png" alt="Description of image">
+  <img src="mud-128.png" alt="muddy logo">
 </p>
 
 HEY!

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2.2.2",
       "license": "0BSD",
       "dependencies": {
-        "@gesslar/actioneer": "^3.0.1",
+        "@gesslar/actioneer": "^3.1.1",
         "@gesslar/colours": "^1.0.0",
-        "@gesslar/toolkit": "^5.4.0",
+        "@gesslar/toolkit": "^5.6.0",
         "adm-zip": "^0.5.17",
         "commander": "^15.0.0",
         "xmlbuilder2": "^4.0.3"
@@ -21,8 +21,7 @@
       },
       "devDependencies": {
         "@gesslar/uglier": "^2.4.1",
-        "console-ninja": "^1.0.0",
-        "eslint": "^10.3.0",
+        "eslint": "^10.5.0",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -171,12 +170,12 @@
       }
     },
     "node_modules/@gesslar/actioneer": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/actioneer/-/actioneer-3.1.0.tgz",
-      "integrity": "sha512-xSM9u09lABt70BtlbYnhR5cuAwQnl1+iH9A7au3HLMwgrPeb8UJjYVo1FlN+CZRKlZkWqfrcxYHAqZrdRyY7JA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@gesslar/actioneer/-/actioneer-3.1.1.tgz",
+      "integrity": "sha512-SCdzcxl3SbCW+GScIkewRIlhL6DY6L7DLdCjMA3Me8ovW9FIv/dbj+YY5BkAdQ4ZTndasHzxZewT69snc/GllQ==",
       "license": "0BSD",
       "dependencies": {
-        "@gesslar/toolkit": "^5.5.2"
+        "@gesslar/toolkit": "^5.6.0"
       },
       "engines": {
         "node": ">=24"
@@ -686,15 +685,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/console-ninja": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/console-ninja/-/console-ninja-1.0.0.tgz",
-      "integrity": "sha512-bRD6vdqXq0PMfzGZ6nllJFMLdG+QXwW+WS5lZcfrgH0r6OsctoJmp1nocF6IIBTT2/1ZPi/OqNAiN6TmRlmWeg==",
-      "dev": true,
-      "bin": {
-        "console-ninja": "shell/console-ninja"
       }
     },
     "node_modules/cross-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -50,19 +50,18 @@
     "minor": "npm version minor",
     "major": "npm version major"
   },
-  "packageManager": "npm@11.14.1",
+  "packageManager": "npm@11.17.0",
   "dependencies": {
-    "@gesslar/actioneer": "^3.0.1",
+    "@gesslar/actioneer": "^3.1.1",
     "@gesslar/colours": "^1.0.0",
-    "@gesslar/toolkit": "^5.4.0",
+    "@gesslar/toolkit": "^5.6.0",
     "adm-zip": "^0.5.17",
     "commander": "^15.0.0",
     "xmlbuilder2": "^4.0.3"
   },
   "devDependencies": {
     "@gesslar/uglier": "^2.4.1",
-    "console-ninja": "^1.0.0",
-    "eslint": "^10.3.0",
+    "eslint": "^10.5.0",
     "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "2.2.2",
+  "version": "2.2.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"


### PR DESCRIPTION
## Dependency Updates

Bumps several dependencies to their latest versions:

- `@gesslar/actioneer` → `^3.1.1`
- `@gesslar/toolkit` → `^5.6.0`
- `commander` → `^15.0.0`
- `eslint` → `^10.5.0`
- `npm` package manager → `11.17.0`

Removes `console-ninja` as a dev dependency.

The `ajv` transitive dependency is also dropped, as `@gesslar/toolkit` no longer requires it.

Additionally moves the "Post Hocktuah" and "Postmate" sections in the README to appear before the License section rather than after it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs routine maintenance: bumps several runtime and dev dependencies, removes the `console-ninja` dev dependency, updates the `packageManager` field to `npm@11.17.0`, and reorganises two README sections to appear before the License section.

- **Dependency updates**: `@gesslar/actioneer` → `^3.1.1`, `@gesslar/toolkit` → `^5.6.0`, `eslint` → `^10.5.0`; `console-ninja` is removed from `devDependencies` and the `ajv` transitive dep is dropped as a result.
- **README**: "Post Hocktuah" and "Postmate" sections moved above the License section; placeholder `alt` text on the logo image corrected from `"Description of image"` to `"muddy logo"`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only dependency version bumps, a dev-dependency removal, and cosmetic README edits.

All changes are limited to dependency version ranges in package.json/package-lock.json and non-functional README text. No source code logic is touched, no new APIs are introduced, and the removed console-ninja was a local-only dev tool with no effect on the built package.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["Fix placeholder alt text in README image"](https://github.com/gesslar/muddy/commit/9c8d33de50410a34663d80626e04df86f51ec68f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38905814)</sub>

<!-- /greptile_comment -->