### PR TITLE
satisyfing a weird edge case that would never happen because even though people are weird, they're not this weird and if they are, ok well, fine.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "3.1.0",
+  "version": "3.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"

--- a/src/Version.js
+++ b/src/Version.js
@@ -42,11 +42,14 @@ export default class Version {
    * Nesting depth is tracked across objects and arrays so a "version" buried
    * inside another structure (e.g. a config block in a package.json) is skipped
    * — only a direct child of the root object counts, regardless of where it sits
-   * or whether a nested one shares its value. Strings are scanned with
+   * or whether a nested one shares its value. Strings are walked with
    * backslash-escape awareness so quotes inside values don't derail the count.
    *
    * Callers validate the text with JSON.parse first, so the input is guaranteed
-   * to be strict JSON — no comments to skip, no trailing-comma surprises.
+   * to be strict JSON: double-quoted strings only, no comments, no trailing
+   * commas. Candidate keys are decoded via JSON.parse rather than compared as raw
+   * text, so an escaped spelling of the key (e.g. "version", which JSON
+   * reads as "version") is matched the same way the parser sees it.
    *
    * @param {string} raw - The file's raw text (already validated as JSON).
    * @returns {{start: number, end: number}|null} The [start, end) span of the
@@ -76,34 +79,25 @@ export default class Version {
         continue
       }
 
-      if(ch !== "\"" && ch !== "'") {
+      if(ch !== "\"") {
         i++
 
         continue
       }
 
-      // Read a complete string token, honouring backslash escapes.
-      const quote = ch
-      let token = ""
+      // Walk to the closing quote, skipping escaped characters. Track the span
+      // so the token can be decoded by the JSON engine if it turns out to be a key.
+      const tokenStart = i
 
       i++
 
-      while(i < length && raw[i] !== quote) {
-        if(raw[i] === "\\") {
-          token += raw[i + 1] ?? ""
-          i += 2
-
-          continue
-        }
-
-        token += raw[i]
-        i++
+      while(i < length && raw[i] !== "\"") {
+        i += raw[i] === "\\" ? 2 : 1
       }
 
       i++ // step past the closing quote
 
-      // Only a depth-1 "version" key — i.e. one followed by a colon — qualifies.
-      if(depth !== 1 || token !== "version")
+      if(depth !== 1)
         continue
 
       let j = i
@@ -111,7 +105,9 @@ export default class Version {
       while(j < length && /\s/.test(raw[j]))
         j++
 
-      if(raw[j] !== ":")
+      // A string followed by ":" is a key. Decode it the way JSON.parse does
+      // before comparing, so escaped spellings of "version" still match.
+      if(raw[j] !== ":" || JSON.parse(raw.slice(tokenStart, i)) !== "version")
         continue
 
       j++
@@ -119,22 +115,14 @@ export default class Version {
       while(j < length && /\s/.test(raw[j]))
         j++
 
-      const valueQuote = raw[j]
-
-      if(valueQuote !== "\"" && valueQuote !== "'")
+      if(raw[j] !== "\"")
         return null
 
       const start = j + 1
       let k = start
 
-      while(k < length && raw[k] !== valueQuote) {
-        if(raw[k] === "\\") {
-          k += 2
-
-          continue
-        }
-
-        k++
+      while(k < length && raw[k] !== "\"") {
+        k += raw[k] === "\\" ? 2 : 1
       }
 
       return {start, end: k}

--- a/test/unit/Version.test.js
+++ b/test/unit/Version.test.js
@@ -166,6 +166,22 @@ describe("version subcommand", () => {
       assert.equal(updated.dependencies[0].version, "9.9.9", "nested dep version untouched")
     })
 
+    it("matches an escaped version key the way JSON.parse decodes it", async() => {
+      // Pathological but valid: "version" is the key "version". JSON.parse
+      // decodes it, so the scanner must too — otherwise the bump can't find it.
+      const mfile = path.join(tmpDir, "mfile")
+      const original = `{\n  "package": "VersionTest",\n  "\\u0076ersion": "1.2.3"\n}\n`
+
+      await writeFile(mfile, original)
+
+      const {code} = await run(tmpDir, ["version", "patch"])
+      assert.equal(code, 0, "should resolve the escaped key to 'version'")
+
+      const updated = await readFile(mfile, "utf8")
+      assert.equal(updated, original.replace("1.2.3", "1.2.4"), "key spelling preserved, value bumped")
+      assert.equal(JSON.parse(updated).version, "1.2.4")
+    })
+
     it("rejects an mfile that isn't strict JSON (e.g. JSON5 comments)", async() => {
       // The mfile must be plain JSON. A JSON5 comment is rejected with a clear
       // error rather than tolerated, and the file is left untouched.


### PR DESCRIPTION
satisyfing a weird edge case that would never happen because even though people are weird, they're not this weird and if they are, ok well, fine.

3.1.1

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates version handling for an escaped root `version` key. The main changes are:

- Package metadata bumped from 3.1.0 to 3.1.1.
- Root JSON version-key scanning now decodes candidate keys before matching.
- A unit test covers bumping an escaped `version` key while preserving its spelling.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (1): Last reviewed commit: ["3.1.1"](https://github.com/gesslar/muddy/commit/97ee983db53f6055ddc8250d4c3e15aa92c2ab2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39835342)</sub>

<!-- /greptile_comment -->