### PR TITLE
Bump version to 3.2.0 and refactor reload to use event-driven install/uninstall

### DIFF
--- a/mpackage/README.md
+++ b/mpackage/README.md
@@ -108,7 +108,6 @@ The quick start is deliberately bare. A "real" helper grows the obvious extras:
 an `active` flag per project so you can park ones you're not touching, fancier
 cache-killing, a little reload-the-helper-itself dance after you edit the list.
 
-
 ## License
 
 Unlike muddy, the Muddy companion package is licensed as MIT because it derives

--- a/mpackage/mfile
+++ b/mpackage/mfile
@@ -1,7 +1,7 @@
 {
   "package": "Muddy",
   "title": "Companion package for muddy.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "gesslar",
   "icon": "src/resources/mud-128.png",
   "dependencies": "",

--- a/mpackage/src/scripts/Muddy.lua
+++ b/mpackage/src/scripts/Muddy.lua
@@ -1,24 +1,24 @@
 ---@type Glu
-local glu = require("Muddy/vendor/Glu-single")("Muddy")
+local glu = require("__PKGNAME__/vendor/Glu-single")("__PKGNAME__")
 local validEvents = {
   "preremove", "postremove",
   "preinstall", "postinstall"
 }
 
-Muddy = Muddy or {
+__PKGNAME__ = __PKGNAME__ or {
   path = getMudletHomeDir(),
   watch = true,
   events = {}
 }
 
 ---@param cons table Constructor arguments.
-function Muddy:new(cons)
+function __PKGNAME__:new(cons)
   local ok, result
 
   ok, result = glu.table.associative(cons)
   if not ok or result == false then
     debugc(
-      "Error in constructor options passed to Muddy, or constructor " ..
+      "Error in constructor options passed to __PKGNAME__, or constructor " ..
       "options is not a table: " .. result
     )
 
@@ -44,7 +44,7 @@ function Muddy:new(cons)
   return instance
 end
 
-function Muddy:start()
+function __PKGNAME__:start()
   self:stop()
   self.watch = true
 
@@ -60,7 +60,7 @@ function Muddy:start()
   addFileWatch(self.outputPath)
 end
 
-function Muddy:stop()
+function __PKGNAME__:stop()
   self.watch = false
   if self.eventHandler then
     killAnonymousEventHandler(self.eventHandler)
@@ -101,29 +101,29 @@ end
 
 local function _uninstall(name, pre, post)
   debugc("preremove " .. name)
-  if prer then
+  if pre then
     debugc(f "  Firing preremove for pkg: {name}")
-    pcall(execute, pre)
+    execute(pre)
     debugc(f "  END premove for pkg: {name}")
   end
 
   uninstallPackage(name)
 
   debugc("postremove " .. name)
-  if postr then
+  if post then
     debugc(f "  Firing postremove for pkg: {name}")
-    pcall(execute, post)
+    execute(post)
     debugc(f "  END postmove for pkg: {name}")
   end
 
-  raiseEvent("muddy:uninstalled", name)
+  raiseEvent("__PKGNAME__:uninstalled", name)
 end
 
 local function _install(name, path, pre, post)
   debugc("preinstall " .. name)
-  if prei then
+  if pre then
     debugc(f "  Firing preinstall for pkg: {name}")
-    pcall(execute, pre)
+    execute(pre)
     debugc(f "  END preinstall for pkg: {name}")
   end
 
@@ -135,14 +135,16 @@ local function _install(name, path, pre, post)
   end
 
   debugc("postinstall " .. name)
-  if posti then
+  if post then
     debugc(f "  Firing postinstall for pkg: {name}")
-    pcall(execute, post)
+    execute(post)
     debugc(f "  END postinstall for pkg: {name}")
   end
+
+  raiseEvent("__PKGNAME__:installed", name)
 end
 
-function Muddy:reload()
+function __PKGNAME__:reload()
   local ok, result, err, output
 
   ok, result, err = pcall(glu.fd.read_json, self.outputPath)
@@ -195,11 +197,11 @@ function Muddy:reload()
 
   local ok, err
 
-  registerAnonymousEventHandler("muddy:uninstalled", function(_, uninstalledName)
-    if uninstalledName ~= name then return end
+  registerAnonymousEventHandler("__PKGNAME__:uninstalled", function(_, uninstalledName)
+    if uninstalledName ~= name then return true end
 
-    registerAnonymousEventHandler("muddy:installed", function(_, installedName)
-      if installedName ~= name then return end
+    registerAnonymousEventHandler("__PKGNAME__:installed", function(_, installedName)
+      if installedName ~= name then return true end
 
       debugc("Done reloading pkg " .. name)
     end, true)

--- a/mpackage/src/scripts/Muddy.lua
+++ b/mpackage/src/scripts/Muddy.lua
@@ -1,18 +1,18 @@
 ---@type Glu
-local glu = require("__PKGNAME__/vendor/Glu-single")("__PKGNAME__")
+local glu = require("Muddy/vendor/Glu-single")("Muddy")
 local validEvents = {
   "preremove", "postremove",
   "preinstall", "postinstall"
 }
 
-__PKGNAME__ = __PKGNAME__ or {
+Muddy = Muddy or {
   path = getMudletHomeDir(),
   watch = true,
   events = {}
 }
 
 ---@param cons table Constructor arguments.
-function __PKGNAME__:new(cons)
+function Muddy:new(cons)
   local ok, result
 
   ok, result = glu.table.associative(cons)
@@ -44,7 +44,7 @@ function __PKGNAME__:new(cons)
   return instance
 end
 
-function __PKGNAME__:start()
+function Muddy:start()
   self:stop()
   self.watch = true
 
@@ -60,7 +60,7 @@ function __PKGNAME__:start()
   addFileWatch(self.outputPath)
 end
 
-function __PKGNAME__:stop()
+function Muddy:stop()
   self.watch = false
   if self.eventHandler then
     killAnonymousEventHandler(self.eventHandler)
@@ -99,7 +99,50 @@ local function execute(item)
   end
 end
 
-function __PKGNAME__:reload()
+local function _uninstall(name, pre, post)
+  debugc("preremove " .. name)
+  if prer then
+    debugc(f "  Firing preremove for pkg: {name}")
+    pcall(execute, pre)
+    debugc(f "  END premove for pkg: {name}")
+  end
+
+  uninstallPackage(name)
+
+  debugc("postremove " .. name)
+  if postr then
+    debugc(f "  Firing postremove for pkg: {name}")
+    pcall(execute, post)
+    debugc(f "  END postmove for pkg: {name}")
+  end
+
+  raiseEvent("muddy:uninstalled", name)
+end
+
+local function _install(name, path, pre, post)
+  debugc("preinstall " .. name)
+  if prei then
+    debugc(f "  Firing preinstall for pkg: {name}")
+    pcall(execute, pre)
+    debugc(f "  END preinstall for pkg: {name}")
+  end
+
+  local succ = installPackage(path)
+  if not succ then
+    debugc("Could not install package at " .. path)
+
+    return
+  end
+
+  debugc("postinstall " .. name)
+  if posti then
+    debugc(f "  Firing postinstall for pkg: {name}")
+    pcall(execute, post)
+    debugc(f "  END postinstall for pkg: {name}")
+  end
+end
+
+function Muddy:reload()
   local ok, result, err, output
 
   ok, result, err = pcall(glu.fd.read_json, self.outputPath)
@@ -150,42 +193,19 @@ function __PKGNAME__:reload()
     =
     self.preremove, self.postremove, self.preinstall, self.postinstall
 
-  debugc("preremove " .. name)
-  if prer then
-    debugc(f "  Firing preremove for pkg: {name}")
-    execute(prer)
-    debugc(f "  END premove for pkg: {name}")
-  end
+  local ok, err
 
-  uninstallPackage(name)
+  registerAnonymousEventHandler("muddy:uninstalled", function(_, uninstalledName)
+    if uninstalledName ~= name then return end
 
-  debugc("postremove " .. name)
-  if postr then
-    debugc(f "  Firing postremove for pkg: {name}")
-    execute(postr)
-    debugc(f "  END postmove for pkg: {name}")
-  end
+    registerAnonymousEventHandler("muddy:installed", function(_, installedName)
+      if installedName ~= name then return end
 
-  debugc("preinstall " .. name)
-  if prei then
-    debugc(f "  Firing preinstall for pkg: {name}")
-    execute(prei)
-    debugc(f "  END preinstall for pkg: {name}")
-  end
+      debugc("Done reloading pkg " .. name)
+    end, true)
 
-  local succ = installPackage(path)
-  if not succ then
-    debugc("Could not install package at " .. path)
+    _install(name, path, prei, posti)
+  end, true)
 
-    return
-  end
-
-  debugc("postinstall " .. name)
-  if posti then
-    debugc(f "  Firing postinstall for pkg: {name}")
-    execute(posti)
-    debugc(f "  END postinstall for pkg: {name}")
-  end
-
-  debugc("Done reloading pkg " .. name)
+  _uninstall(name, prer, postr)
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "3.1.1",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"


### PR DESCRIPTION
Refactors the package reload flow to use event-driven sequencing for uninstall/install operations. The inline uninstall and install logic has been extracted into dedicated `_uninstall` and `_install` local functions, and the `reload` method now uses anonymous event handlers to ensure installation only begins after uninstallation has completed, rather than executing both steps synchronously.

A `muddy:uninstalled` event is raised at the end of `_uninstall`, which triggers `_install` via a one-shot event handler. A `muddy:installed` handler is also registered to confirm when the reload cycle is fully complete.

Bumps the package version to `3.2.0` and the companion Mudlet package version to `1.1.0`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the release versions and changes package reloads to use event callbacks. The main changes are:

- Updated npm package metadata to `3.2.0`.
- Updated the Mudlet companion package version to `1.1.0`.
- Moved reload uninstall and install work into `_uninstall` and `_install` helpers.
- Sequenced reload install work from `__PKGNAME__:uninstalled` and `__PKGNAME__:installed` events.

<h3>Confidence Score: 4/5</h3>

This is close, but the self-reload path should be fixed before merging.

- Reload now depends on an anonymous handler surviving the uninstall step.
- If the package reloads itself, uninstall can remove the continuation before install starts.
- The previous inline reload path did not have that lifecycle dependency.

mpackage/src/scripts/Muddy.lua

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ampackage%2Fsrc%2Fscripts%2FMuddy.lua%3A209%0A**Self%20Reload%20Can%20Stall**%0A%0AWhen%20%60reload%28%29%60%20is%20used%20for%20the%20package%20that%20owns%20this%20script%2C%20the%20continuation%20handler%20is%20registered%20and%20then%20%60_uninstall%28%29%60%20immediately%20calls%20%60uninstallPackage%28name%29%60.%20If%20Mudlet%20removes%20that%20package's%20anonymous%20handlers%20during%20uninstall%2C%20the%20%60__PKGNAME__%3Auninstalled%60%20listener%20is%20gone%20before%20%60_uninstall%28%29%60%20raises%20the%20event%2C%20so%20%60_install%28name%2C%20path%2C%20prei%2C%20posti%29%60%20never%20runs%20and%20the%20package%20stays%20uninstalled.%20The%20old%20inline%20flow%20did%20not%20depend%20on%20a%20package-owned%20handler%20surviving%20its%20own%20uninstall.%0A%0A&repo=gesslar%2Fmuddy&pr=77&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["3.2.0"](https://github.com/gesslar/muddy/commit/d7a10dbd1321f2a6c89c9272df957ad4d0cffb04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39908119)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->