### PR TITLE
Bump version to 3.2.1, fix typos, and use icon filename only in package output

### DIFF
--- a/mpackage/mfile
+++ b/mpackage/mfile
@@ -1,7 +1,7 @@
 {
   "package": "Muddy",
   "title": "Companion package for muddy.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "gesslar",
   "icon": "src/resources/mud-128.png",
   "dependencies": "",

--- a/mpackage/src/scripts/Muddy.lua
+++ b/mpackage/src/scripts/Muddy.lua
@@ -1,9 +1,5 @@
 ---@type Glu
 local glu = require("__PKGNAME__/vendor/Glu-single")("__PKGNAME__")
-local validEvents = {
-  "preremove", "postremove",
-  "preinstall", "postinstall"
-}
 
 __PKGNAME__ = __PKGNAME__ or {
   path = getMudletHomeDir(),
@@ -104,7 +100,7 @@ local function _uninstall(name, pre, post)
   if pre then
     debugc(f "  Firing preremove for pkg: {name}")
     execute(pre)
-    debugc(f "  END premove for pkg: {name}")
+    debugc(f "  END preremove for pkg: {name}")
   end
 
   uninstallPackage(name)
@@ -113,7 +109,7 @@ local function _uninstall(name, pre, post)
   if post then
     debugc(f "  Firing postremove for pkg: {name}")
     execute(post)
-    debugc(f "  END postmove for pkg: {name}")
+    debugc(f "  END postremove for pkg: {name}")
   end
 
   raiseEvent("__PKGNAME__:uninstalled", name)
@@ -194,8 +190,6 @@ function __PKGNAME__:reload()
     prer, postr, prei, posti
     =
     self.preremove, self.postremove, self.preinstall, self.postinstall
-
-  local ok, err
 
   registerAnonymousEventHandler("__PKGNAME__:uninstalled", function(_, uninstalledName)
     if uninstalledName ~= name then return true end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "3.2.0",
+  "version": "3.2.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"

--- a/src/Muddy.js
+++ b/src/Muddy.js
@@ -565,7 +565,12 @@ export default class Muddy {
       if(value === undefined || value === null || value === "")
         continue
 
-      out.push(`${v} = ${Lua.longString(String(value))}`)
+      // If this is icon, we only need the icon's name. Mudlet handles the
+      // rest.
+      if(k === "icon")
+        out.push(`${v} = ${Lua.longString(String(new FileObject(value).name))}`)
+      else
+        out.push(`${v} = ${Lua.longString(String(value))}`)
     }
 
     // This isn't sourced anywhere, so we just make it up.


### PR DESCRIPTION
Fixes a typo in debug messages where `premove` and `postmove` were corrected to `preremove` and `postremove`. Removes the unused `validEvents` table and an unused `ok, err` variable declaration. Corrects icon handling so that only the icon's filename is passed rather than the full path, since Mudlet resolves the rest itself. Bumps the version to `1.1.1` / `3.2.1`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the package metadata and cleans up a few Muddy packaging details.

- Version bumps for npm and Mudlet package metadata.
- Corrected `preremove` and `postremove` debug messages.
- Removed unused Lua locals and event data.
- Serialized package icons by filename instead of the full path.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small hardening cleanup.

- No blocking issues found in the changed code.
- The icon serialization path now depends on `FileObject` accepting raw icon values without the directory context used elsewhere.

src/Muddy.js

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2FMuddy.js%3A570%0A**Icon%20Path%20Constructor%20Dependency**%0A%0AWhen%20%60mfile.icon%60%20is%20the%20normal%20relative%20path%20from%20%60mpackage%2Fmfile%60%2C%20this%20path%20now%20constructs%20a%20%60FileObject%60%20without%20the%20directory%20context%20used%20elsewhere%20before%20writing%20%60config.lua%60.%20If%20that%20constructor%20requires%20a%20parent%20directory%20or%20rejects%20non-file-style%20icon%20strings%2C%20package%20generation%20fails%20instead%20of%20just%20serializing%20the%20icon%20filename.%0A%0A&repo=gesslar%2Fmuddy&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["3.2.1"](https://github.com/gesslar/muddy/commit/db8ca9ceb991e813a4d247fb233c5885f61b2f34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39927933)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: Commented-out code may remain only when it d... ([source](https://app.greptile.com/gesslar/-/custom-context?memory=a0d38c94-cefe-402e-b354-4a9a427afad4))
- Rule used - Do not flag self-reload risks in Muddy.lua — reloa... ([source](https://app.greptile.com/gesslar/github/gesslar/muddy/-/custom-context?memory=0833a8d6-8873-475b-a2fd-649b0849e72e))

<!-- /greptile_comment -->