### PR TITLE
Bump version to 3.2.2, add Mudlet version check, and fix install/uninstall error handling

### DIFF
--- a/mpackage/mfile
+++ b/mpackage/mfile
@@ -1,7 +1,7 @@
 {
   "package": "Muddy",
   "title": "Companion package for muddy.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "gesslar",
   "icon": "src/resources/mud-128.png",
   "dependencies": "",

--- a/mpackage/src/scripts/Muddy.lua
+++ b/mpackage/src/scripts/Muddy.lua
@@ -21,18 +21,20 @@ function __PKGNAME__:new(cons)
 
   local ok, result
 
-  ok, result = glu.table.associative(cons)
+  ok, result = pcall(glu.table.associative, cons)
   if not ok then
-    if result == false then
-      debugc(
-        "Error in constructor options passed to __PKGNAME__, or constructor " ..
-        "options is not a table."
-      )
-    else
-      debugc(
-        "Error in constructor options passed to __PKGNAME__ " .. tostring(result)
-      )
-    end
+    debugc(
+      "Error in constructor options passed to __PKGNAME__ " .. tostring(result)
+    )
+
+    return
+  end
+
+  if result == false then
+    debugc(
+      "Error in constructor options passed to __PKGNAME__, or constructor " ..
+      "options is not a table."
+    )
 
     return
   end
@@ -112,31 +114,39 @@ local function execute(item)
 end
 
 local function _uninstall(self, name, pre, post)
-  debugc("preremove " .. name)
-  if pre then
-    debugc(f "  Firing preremove for pkg: {name}")
-    execute(pre)
-    debugc(f "  END preremove for pkg: {name}")
-  end
+  local installed = table.contains(getPackages(), name)
 
-  local succ = uninstallPackage(name)
-  if not succ then
-    debugc("Could not uninstall package at " .. name)
-
-    if self.uninstallHandle then
-      killAnonymousEventHandler(self.uninstallHandle)
+  if installed == true then
+    debugc("preremove " .. name)
+    if pre then
+      debugc(f "  Firing preremove for pkg: {name}")
+      execute(pre)
+      debugc(f "  END preremove for pkg: {name}")
     end
 
-    return
+    local succ = uninstallPackage(name)
+    if not succ then
+      debugc("Could not uninstall package at " .. name)
+
+      if self.uninstallHandle then
+        killAnonymousEventHandler(self.uninstallHandle)
+      end
+
+      return
+    end
+
+    debugc("postremove " .. name)
+    if post then
+      debugc(f "  Firing postremove for pkg: {name}")
+      execute(post)
+      debugc(f "  END postremove for pkg: {name}")
+    end
+
   end
 
-  debugc("postremove " .. name)
-  if post then
-    debugc(f "  Firing postremove for pkg: {name}")
-    execute(post)
-    debugc(f "  END postremove for pkg: {name}")
-  end
-
+  -- doesn't matter, just pretend like we uninstalled when something wasn't
+  -- even installed in the first place. nobody will know. it'll be our little
+  -- secret.
   raiseEvent("__PKGNAME__:uninstalled", name)
 end
 

--- a/mpackage/src/scripts/Muddy.lua
+++ b/mpackage/src/scripts/Muddy.lua
@@ -1,5 +1,6 @@
 ---@type Glu
 local glu = require("__PKGNAME__/vendor/Glu-single")("__PKGNAME__")
+local requiredVersion = "4.20.0"
 
 __PKGNAME__ = __PKGNAME__ or {
   path = getMudletHomeDir(),
@@ -9,14 +10,29 @@ __PKGNAME__ = __PKGNAME__ or {
 
 ---@param cons table Constructor arguments.
 function __PKGNAME__:new(cons)
+  local version = getMudletVersion("string")
+  if glu.version.compare(version, requiredVersion) == -1 then
+    debugc(
+      "This __PKGNAME__ package requires at least version " .. requiredVersion
+    )
+
+    return
+  end
+
   local ok, result
 
   ok, result = glu.table.associative(cons)
-  if not ok or result == false then
-    debugc(
-      "Error in constructor options passed to __PKGNAME__, or constructor " ..
-      "options is not a table: " .. result
-    )
+  if not ok then
+    if result == false then
+      debugc(
+        "Error in constructor options passed to __PKGNAME__, or constructor " ..
+        "options is not a table."
+      )
+    else
+      debugc(
+        "Error in constructor options passed to __PKGNAME__ " .. tostring(result)
+      )
+    end
 
     return
   end
@@ -79,7 +95,7 @@ local function execute(item)
       f, e = loadstring(item)
     end
     if not f then
-      debugc("Unable to convert string to function for execution in Muddler hook:" .. e)
+      debugc("Unable to convert string to function for execution in Muddy hook:" .. e)
       return
     end
     item = f
@@ -95,7 +111,7 @@ local function execute(item)
   end
 end
 
-local function _uninstall(name, pre, post)
+local function _uninstall(self, name, pre, post)
   debugc("preremove " .. name)
   if pre then
     debugc(f "  Firing preremove for pkg: {name}")
@@ -103,7 +119,16 @@ local function _uninstall(name, pre, post)
     debugc(f "  END preremove for pkg: {name}")
   end
 
-  uninstallPackage(name)
+  local succ = uninstallPackage(name)
+  if not succ then
+    debugc("Could not uninstall package at " .. name)
+
+    if self.uninstallHandle then
+      killAnonymousEventHandler(self.uninstallHandle)
+    end
+
+    return
+  end
 
   debugc("postremove " .. name)
   if post then
@@ -115,7 +140,7 @@ local function _uninstall(name, pre, post)
   raiseEvent("__PKGNAME__:uninstalled", name)
 end
 
-local function _install(name, path, pre, post)
+local function _install(self, name, path, pre, post)
   debugc("preinstall " .. name)
   if pre then
     debugc(f "  Firing preinstall for pkg: {name}")
@@ -126,6 +151,10 @@ local function _install(name, path, pre, post)
   local succ = installPackage(path)
   if not succ then
     debugc("Could not install package at " .. path)
+
+    if self.installHandle then
+      killAnonymousEventHandler(self.installHandle)
+    end
 
     return
   end
@@ -191,17 +220,25 @@ function __PKGNAME__:reload()
     =
     self.preremove, self.postremove, self.preinstall, self.postinstall
 
-  registerAnonymousEventHandler("__PKGNAME__:uninstalled", function(_, uninstalledName)
-    if uninstalledName ~= name then return true end
+  self.uninstallHandle = registerAnonymousEventHandler(
+    "__PKGNAME__:uninstalled",
+    function(_, uninstalledName)
+      if uninstalledName ~= name then return true end
 
-    registerAnonymousEventHandler("__PKGNAME__:installed", function(_, installedName)
-      if installedName ~= name then return true end
+      self.installHandle = registerAnonymousEventHandler(
+        "__PKGNAME__:installed",
+        function(_, installedName)
+          if installedName ~= name then return true end
 
-      debugc("Done reloading pkg " .. name)
-    end, true)
+          debugc("Done reloading pkg " .. name)
+        end,
+        true
+      )
 
-    _install(name, path, prei, posti)
-  end, true)
+      _install(self, name, path, prei, posti)
+    end,
+    true
+  )
 
-  _uninstall(name, prer, postr)
+  _uninstall(self, name, prer, postr)
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/muddy",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/muddy",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "0BSD",
       "dependencies": {
         "@gesslar/actioneer": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "3.2.1",
+  "version": "3.2.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gesslar/muddy.git"


### PR DESCRIPTION
Adds a minimum Mudlet version check (`4.20.0`) on initialization, returning early with a debug message if the requirement is not met.

Fixes error handling in the constructor to distinguish between a `false` result and an actual error message, providing more accurate debug output in each case.

Passes `self` into `_install` and `_uninstall` so that anonymous event handlers can be cleaned up via `killAnonymousEventHandler` when an install or uninstall operation fails.

Stores the handles returned by `registerAnonymousEventHandler` on `self` (`installHandle` and `uninstallHandle`) so they are accessible for cleanup during the reload flow.

Corrects a typo in a debug message that incorrectly referenced "Muddler" instead of "Muddy".

Bumps the package version to `1.1.2` / `3.2.2`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Muddy package initialization and reload handling. The main changes are:

- Minimum Mudlet version check during construction.
- More specific constructor option validation logging.
- Reload install and uninstall handler cleanup on failure.
- Package version bumps in metadata and npm files.

<h3>Confidence Score: 4/5</h3>

This is close, but the constructor path should be fixed before merging.

- Valid constructor inputs can return before initialization runs.
- The reload absent-package flow now falls through to installation.

mpackage/src/scripts/Muddy.lua

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ampackage%2Fsrc%2Fscripts%2FMuddy.lua%3A36%0A**Constructor%20Always%20Returns**%0A%0AThe%20validation%20branch%20now%20closes%20before%20this%20%60return%60%2C%20so%20a%20successful%20%60pcall%28glu.table.associative%2C%20cons%29%60%20still%20exits%20the%20constructor%20before%20the%20object%20is%20initialized.%20Valid%20constructor%20options%20now%20stop%20at%20validation%20instead%20of%20reaching%20the%20setup%20code%2C%20so%20callers%20get%20no%20usable%20package%20instance.%20The%20return%20should%20stay%20inside%20the%20validation%20failure%20paths.%0A%0A&repo=gesslar%2Fmuddy&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["3.2.2"](https://github.com/gesslar/muddy/commit/56140087c891deae57d7f78b4116d584cc5a77c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39980365)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->